### PR TITLE
fix: add an option to override http.Client used by jar parser

### DIFF
--- a/pkg/jar/parse.go
+++ b/pkg/jar/parse.go
@@ -36,6 +36,7 @@ var (
 
 type conf struct {
 	baseURL      string
+	client       *http.Client
 	rootFilePath string
 }
 
@@ -53,8 +54,14 @@ func WithFilePath(filePath string) Option {
 	}
 }
 
+func WithClient(client *http.Client) Option {
+	return func(c *conf) {
+		c.client = client
+	}
+}
+
 func Parse(r io.Reader, opts ...Option) ([]types.Library, error) {
-	c := conf{baseURL: baseURL}
+	c := conf{baseURL: baseURL, client: http.DefaultClient}
 	for _, opt := range opts {
 		opt(&c)
 	}
@@ -374,7 +381,7 @@ func exists(c conf, p properties) (bool, error) {
 	q.Set("rows", "1")
 	req.URL.RawQuery = q.Encode()
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return false, xerrors.Errorf("http error: %w", err)
 	}
@@ -406,7 +413,7 @@ func searchBySHA1(c conf, data []byte) (properties, error) {
 	q.Set("wt", "json")
 	req.URL.RawQuery = q.Encode()
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return properties{}, xerrors.Errorf("sha1 search error: %w", err)
 	}
@@ -448,7 +455,7 @@ func searchByArtifactID(c conf, artifactID string) (string, error) {
 	q.Set("wt", "json")
 	req.URL.RawQuery = q.Encode()
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return "", xerrors.Errorf("artifactID search error: %w", err)
 	}

--- a/pkg/jar/parse_test.go
+++ b/pkg/jar/parse_test.go
@@ -155,7 +155,7 @@ func TestParse(t *testing.T) {
 			f, err := os.Open(v.file)
 			require.NoError(t, err)
 
-			got, err := jar.Parse(f, jar.WithURL(ts.URL), jar.WithFilePath(v.file))
+			got, err := jar.Parse(f, jar.WithURL(ts.URL), jar.WithFilePath(v.file), jar.WithClient(ts.Client()))
 			require.NoError(t, err)
 
 			sort.Slice(got, func(i, j int) bool {


### PR DESCRIPTION
This would enable the embedder of this library to decide whether to allow or disallow network calls to maven central. Those who don't want the remote call shall pass dummy client.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>