### PR TITLE
fix(gomod): skip an empty line

### DIFF
--- a/pkg/gomod/parse.go
+++ b/pkg/gomod/parse.go
@@ -16,8 +16,12 @@ func Parse(r io.Reader) ([]types.Library, error) {
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 		s := strings.Fields(line)
+		if len(s) < 2 {
+			continue
+		}
+
 		// go.sum records and sorts all non-major versions
 		// with the latest version as last entry
 		uniqueLibs[s[0]] = strings.TrimSuffix(strings.TrimPrefix(s[1], "v"), "/go.mod")

--- a/pkg/gomod/parse_test.go
+++ b/pkg/gomod/parse_test.go
@@ -22,6 +22,10 @@ func TestParse(t *testing.T) {
 			want: GoModNormal,
 		},
 		{
+			file: "testdata/gomod_emptyline.sum",
+			want: GoModEmptyLine,
+		},
+		{
 			file: "testdata/gomod_many.sum",
 			want: GoModMany,
 		},

--- a/pkg/gomod/parse_testcase.go
+++ b/pkg/gomod/parse_testcase.go
@@ -14,6 +14,12 @@ var (
 		{"golang.org/x/xerrors", "0.0.0-20200804184101-5ec99f83aff1"},
 	}
 
+	// https://github.com/uudashr/gopkgs/blob/616744904701ef01d868da4b66aad0e6856c361d/v2/go.sum
+	GoModEmptyLine = []types.Library{
+		{"github.com/karrick/godirwalk", "1.12.0"},
+		{"github.com/pkg/errors", "0.8.1"},
+	}
+
 	// docker run --name gomod --rm -it golang:1.15 bash
 	// export USER=gomod
 	// mkdir repo

--- a/pkg/gomod/testdata/gomod_emptyline.sum
+++ b/pkg/gomod/testdata/gomod_emptyline.sum
@@ -1,0 +1,5 @@
+github.com/karrick/godirwalk v1.12.0 h1:nkS4xxsjiZMvVlazd0mFyiwD4BR9f3m6LXGhM2TUx3Y=
+github.com/karrick/godirwalk v1.12.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+


### PR DESCRIPTION
## Issue
https://github.com/aquasecurity/trivy/issues/1004

## Error

```
panic: runtime error: index out of range [1] with length 0

goroutine 7430 [running]:
github.com/aquasecurity/go-dep-parser/pkg/gomod.Parse(0x22792e0, 0xc000b929c0, 0x10f8117, 0xc0003d2a90, 0xc00017e180, 0x2b, 0x80)
        /Users/teppei/pkg/mod/github.com/aquasecurity/go-dep-parser@v0.0.0-20210427143403-3c97ccc53976/pkg/gomod/parse.go:23 +0x56f
github.com/aquasecurity/fanal/analyzer/library.Analyze(0x2075788, 0x5, 0xc0000419b0, 0x2a, 0xc00096ac00, 0x153, 0x200, 0x20cb358, 0x200, 0x20cb350, ...)
        /Users/teppei/src/github.com/aquasecurity/fanal/analyzer/library/analyze.go:18 +0x93
github.com/aquasecurity/fanal/analyzer/library/gomod.gomodAnalyzer.Analyze(0xc0000419b0, 0x2a, 0xc00096ac00, 0x153, 0x200, 0x0, 0x0, 0x0)
        /Users/teppei/src/github.com/aquasecurity/fanal/analyzer/library/gomod/gomod.go:29 +0x10b
github.com/aquasecurity/fanal/analyzer.Analyzer.AnalyzeFile.func1(0xc0009b6050, 0xc00071a4d0, 0xc0008c60c0, 0x2296fc0, 0x2a71188, 0xc0000419b0, 0x2a, 0xc00096ac00, 0x153, 0x200)
        /Users/teppei/src/github.com/aquasecurity/fanal/analyzer/analyzer.go:207 +0xd9
created by github.com/aquasecurity/fanal/analyzer.Analyzer.AnalyzeFile
        /Users/teppei/src/github.com/aquasecurity/fanal/analyzer/analyzer.go:203 +0x2f2
```