### PR TITLE
fix(gobinary): check first column to determine meaning

### DIFF
--- a/pkg/gobinary/parse_test.go
+++ b/pkg/gobinary/parse_test.go
@@ -72,6 +72,20 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:      "with replace directive",
+			inputFile: "testdata/replace.elf",
+			want: []types.Library{
+				{
+					Name:    "github.com/davecgh/go-spew",
+					Version: "v1.1.1",
+				},
+				{
+					Name:    "github.com/go-sql-driver/mysql",
+					Version: "v1.5.0",
+				},
+			},
+		},
+		{
 			name:      "sad path",
 			inputFile: "testdata/dummy",
 			wantErr:   "unrecognized executable format",


### PR DESCRIPTION
I updated the gobinary line checking logic to understand replace directive("=>") and also added ability to understand lines without hash values.

I do not know why i do not get hash values when i build binary in a container with vendor folder but you can find the steps in [this repo](https://github.com/ebati/trivy-mod-parse). The test binary (replace.elf) is also from the code in that repo.

Related to aquasecurity/trivy/issues/980