### PR TITLE
 fix(yarn): support quoted version

### DIFF
--- a/pkg/nodejs/npm/parse_testcase.go
+++ b/pkg/nodejs/npm/parse_testcase.go
@@ -3,7 +3,7 @@ package npm
 import "github.com/aquasecurity/go-dep-parser/pkg/types"
 
 var (
-	// docker run --name composer --rm -it node:12-alpine sh
+	// docker run --name node --rm -it node:12-alpine sh
 	// npm init --force
 	// npm install --save promise jquery
 	// npm ls | grep -E -o "\S+@\S+" | awk -F@ 'NR>0 {printf("{\""$1"\", \""$2"\", \"\"},\n")}'
@@ -13,7 +13,7 @@ var (
 		{"promise", "8.0.3", ""},
 	}
 
-	// docker run --name composer --rm -it node:12-alpine sh
+	// docker run --name node --rm -it node:12-alpine sh
 	// npm init --force
 	// npm install --save react redux
 	// npm ls | grep -E -o "\S+@\S+" | awk -F@ 'NR>0 {printf("{\""$1"\", \""$2"\", \"\"},\n")}'
@@ -32,7 +32,7 @@ var (
 		{"symbol-observable", "1.2.0", ""},
 	}
 
-	// docker run --name composer --rm -it node:12-alpine sh
+	// docker run --name node --rm -it node:12-alpine sh
 	// npm init --force
 	// npm install --save react redux
 	// npm install --save-dev mocha
@@ -52,7 +52,7 @@ var (
 		{"symbol-observable", "1.2.0", ""},
 	}
 
-	// docker run --name composer --rm -it node:12-alpine sh
+	// docker run --name node --rm -it node:12-alpine sh
 	// npm init --force
 	// npm install --save react redux
 	// npm install --save-dev mocha

--- a/pkg/nodejs/yarn/parse.go
+++ b/pkg/nodejs/yarn/parse.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	yarnLocatorRegexp = regexp.MustCompile(`"?(?P<package>.+?)@(?:(?P<protocol>.+?):)?.+`)
-	yarnVersionRegexp = regexp.MustCompile(`\s+version:?\s+"?(?P<version>[^"]+)"?`)
+	yarnVersionRegexp = regexp.MustCompile(`\s+"?version:?"?\s+"?(?P<version>[^"]+)"?`)
 )
 
 type LockFile struct {

--- a/pkg/nodejs/yarn/parse_test.go
+++ b/pkg/nodejs/yarn/parse_test.go
@@ -81,6 +81,10 @@ func TestParse(t *testing.T) {
 			want: yarnRealWorld,
 		},
 		{
+			file: "testdata/yarn_with_npm.lock",
+			want: yarnWithNpm,
+		},
+		{
 			file: "testdata/yarn_v2_normal.lock",
 			want: yarnV2Normal,
 		},

--- a/pkg/nodejs/yarn/parse_testcase.go
+++ b/pkg/nodejs/yarn/parse_testcase.go
@@ -3,7 +3,7 @@ package yarn
 import "github.com/aquasecurity/go-dep-parser/pkg/types"
 
 var (
-	// docker run --name composer --rm -it node:12-alpine sh
+	// docker run --name node --rm -it node:12-alpine sh
 	// yarn init -y
 	// yarn add promise jquery
 	// yarn list | grep -E -o "\S+@[^\^~]\S+" | awk -F@ 'NR>0 {printf("{\""$1"\", \""$2"\", \"\"},\n")}'
@@ -2838,5 +2838,14 @@ var (
 		{"yargs-unparser", "1.6.1", ""},
 		{"yargs", "13.3.2", ""},
 		{"yargs", "14.2.3", ""},
+	}
+
+	// docker run --name node --rm -it node:16-alpine sh
+	// mkdir app && cd app
+	// yarn init -y
+	// yarn add jquery
+	// npm install
+	yarnWithNpm = []types.Library{
+		{"jquery", "3.6.0", ""},
 	}
 )

--- a/pkg/nodejs/yarn/testdata/yarn_with_npm.lock
+++ b/pkg/nodejs/yarn/testdata/yarn_with_npm.lock
@@ -1,0 +1,4 @@
+"jquery@^3.6.0":
+  "integrity" "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+  "resolved" "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz"
+  "version" "3.6.0"


### PR DESCRIPTION
## Description
npm v7 supports `yarn.lock` as well as `package-lock.json`. Also, it updates `yarn.lock`. But the format is different from the original one.

Each key is not quoted as below.

```
$ yarn init -y
$ yarn add jquery
$ cat yarn.lock
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1


jquery@^3.6.0:
  version "3.6.0"
  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
```

On the other hand, once`npm` updates `yarn.lock`, keys are double-quoted.

```
$ npm install
/app # cat yarn.lock
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1


"jquery@^3.6.0":
  "integrity" "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
  "resolved" "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz"
  "version" "3.6.0"
```

This PR supports the quoted version.