### PR TITLE
fix(python): fix parsing of requirements.txt with hash checking mode available in pip since version 8.0

### DIFF
--- a/pkg/python/pip/parse.go
+++ b/pkg/python/pip/parse.go
@@ -13,6 +13,7 @@ import (
 const (
 	commentMarker string = "#"
 	endColon      string = ";"
+	hashMarker    string = "--"
 )
 
 func Parse(r io.Reader) ([]types.Library, error) {
@@ -21,8 +22,10 @@ func Parse(r io.Reader) ([]types.Library, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		line = strings.ReplaceAll(line, " ", "")
+		line = strings.ReplaceAll(line, `\`, "")
 		line = rStripByKey(line, commentMarker)
 		line = rStripByKey(line, endColon)
+		line = rStripByKey(line, hashMarker)
 		s := strings.Split(line, "==")
 		if len(s) != 2 {
 			continue

--- a/pkg/python/pip/parse_test.go
+++ b/pkg/python/pip/parse_test.go
@@ -36,6 +36,10 @@ func TestParse(t *testing.T) {
 			file: "testdata/requirements_operator.txt",
 			want: requirementsOperator,
 		},
+		{
+			file: "testdata/requirements_hash.txt",
+			want: requirementsHash,
+		},
 	}
 
 	for _, v := range vectors {

--- a/pkg/python/pip/parse_testcase.go
+++ b/pkg/python/pip/parse_testcase.go
@@ -34,4 +34,9 @@ var (
 		{"Django", "2.3.4", ""},
 		{"SomeProject", "5.4", ""},
 	}
+
+	requirementsHash = []types.Library{
+		{"FooProject", "1.2", ""},
+		{"Jinja2", "3.0.0", ""},
+	}
 )

--- a/pkg/python/pip/testdata/requirements_hash.txt
+++ b/pkg/python/pip/testdata/requirements_hash.txt
@@ -1,0 +1,6 @@
+FooProject == 1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 \
+                  --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7
+
+Jinja2 == 3.0.0 \
+    --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 \
+    --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7


### PR DESCRIPTION
[Hash-Checking Mode](https://pip.pypa.io/en/stable/cli/pip_install/#hash-checking-mode) available in pip since version 8.0 causes the current pip parser to fail, this will fix the pip parsing
  
Fixes https://github.com/aquasecurity/fanal/issues/323