### PR TITLE
fix(go/binary): avoid reading all

### DIFF
--- a/pkg/golang/binary/parse.go
+++ b/pkg/golang/binary/parse.go
@@ -7,14 +7,18 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"io"
 	"strings"
 
+	"golang.org/x/xerrors"
+
+	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
 	"github.com/aquasecurity/go-dep-parser/pkg/types"
 )
 
+var ErrNonGoBinary = xerrors.New("non go binary")
+
 // Parse scans file to try to report the Go and module versions.
-func Parse(r io.Reader) ([]types.Library, error) {
+func Parse(r dio.ReadSeekerAt) ([]types.Library, error) {
 	x, err := openExe(r)
 	if err != nil {
 		return nil, err
@@ -22,7 +26,7 @@ func Parse(r io.Reader) ([]types.Library, error) {
 
 	vers, mod := findVers(x)
 	if vers == "" {
-		return nil, nil
+		return nil, ErrNonGoBinary
 	}
 
 	var libs []types.Library

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -1,0 +1,25 @@
+package io
+
+import "io"
+
+type ReadSeekerAt interface {
+	io.ReadSeeker
+	io.ReaderAt
+}
+
+type ReadSeekCloserAt interface {
+	io.ReadSeekCloser
+	io.ReaderAt
+}
+
+// NopCloser returns a ReadSeekCloserAt with a no-op Close method wrapping
+// the provided Reader r.
+func NopCloser(r ReadSeekerAt) ReadSeekCloserAt {
+	return nopCloser{r}
+}
+
+type nopCloser struct {
+	ReadSeekerAt
+}
+
+func (nopCloser) Close() error { return nil }


### PR DESCRIPTION
## Description
Do not use ioutil.ReadAll() for improving performance.