### PR TITLE
fix(pip): handling a package name with a hyphen

### DIFF
--- a/pkg/python/pip/parse.go
+++ b/pkg/python/pip/parse.go
@@ -42,7 +42,7 @@ func Parse(r io.Reader) ([]types.Library, error) {
 }
 
 func rStripByKey(line string, key string) string {
-	if pos := strings.IndexAny(line, key); pos >= 0 {
+	if pos := strings.Index(line, key); pos >= 0 {
 		line = strings.TrimRightFunc((line)[:pos], unicode.IsSpace)
 	}
 	return line

--- a/pkg/python/pip/parse_test.go
+++ b/pkg/python/pip/parse_test.go
@@ -40,6 +40,10 @@ func TestParse(t *testing.T) {
 			file: "testdata/requirements_hash.txt",
 			want: requirementsHash,
 		},
+		{
+			file: "testdata/requirements_hyphens.txt",
+			want: requirementsHyphens,
+		},
 	}
 
 	for _, v := range vectors {

--- a/pkg/python/pip/parse_testcase.go
+++ b/pkg/python/pip/parse_testcase.go
@@ -39,4 +39,9 @@ var (
 		{"FooProject", "1.2", ""},
 		{"Jinja2", "3.0.0", ""},
 	}
+
+	requirementsHyphens = []types.Library{
+		{"oauth2-client", "4.0.0", ""},
+		{"python-gitlab", "2.0.0", ""},
+	}
 )

--- a/pkg/python/pip/testdata/requirements_hyphens.txt
+++ b/pkg/python/pip/testdata/requirements_hyphens.txt
@@ -1,0 +1,2 @@
+oauth2-client==4.0.0
+python-gitlab==2.0.0


### PR DESCRIPTION
Changed getting the index of the first instance of substr instead of the index of the first instance of any Unicode code point from chars.

Fixes #81 