### PR TITLE
fix(pom): keep an order of dependencies

### DIFF
--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -302,26 +302,20 @@ func (p parser) parseDependencies(deps []pomDependency, props map[string]string,
 }
 
 func (p parser) mergeDependencies(parent, child []artifact, exclusions map[string]struct{}) []artifact {
-	unique := map[string]artifact{}
-	for _, d := range child {
-		if _, ok := exclusions[d.Name()]; ok {
-			continue
-		}
-		unique[d.Name()] = d
-	}
-	for _, d := range parent {
-		if _, ok := exclusions[d.Name()]; ok {
-			continue
-		}
-		if _, ok := unique[d.Name()]; !ok {
-			unique[d.Name()] = d
-		}
-	}
-
 	var deps []artifact
-	for _, d := range unique {
+	unique := map[string]struct{}{}
+
+	for _, d := range append(parent, child...) {
+		if _, ok := exclusions[d.Name()]; ok {
+			continue
+		}
+		if _, ok := unique[d.Name()]; ok {
+			continue
+		}
+		unique[d.Name()] = struct{}{}
 		deps = append(deps, d)
 	}
+
 	return deps
 }
 

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -161,6 +161,29 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "soft requirement with transitive dependencies",
+			inputFile: filepath.Join("testdata", "soft-requirement-with-transitive-dependencies", "pom.xml"),
+			local:     true,
+			want: []types.Library{
+				{
+					Name:    "com.example:soft-transitive",
+					Version: "1.0.0",
+				},
+				{
+					Name:    "org.example:example-api",
+					Version: "2.0.0",
+				},
+				{
+					Name:    "org.example:example-dependency",
+					Version: "1.2.3",
+				},
+				{
+					Name:    "org.example:example-dependency2",
+					Version: "2.3.4",
+				},
+			},
+		},
+		{
 			name:      "hard requirement for the specified version",
 			inputFile: filepath.Join("testdata", "hard-requirement", "pom.xml"),
 			local:     true,

--- a/pkg/java/pom/testdata/repository/org/example/example-dependency2/2.3.4/example-dependency2-2.3.4.pom
+++ b/pkg/java/pom/testdata/repository/org/example/example-dependency2/2.3.4/example-dependency2-2.3.4.pom
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-dependency2</artifactId>
+    <version>2.3.4</version>
+
+    <packaging>jar</packaging>
+    <name>Example API Dependency</name>
+    <description>The example API</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/java/pom/testdata/soft-requirement-with-transitive-dependencies/pom.xml
+++ b/pkg/java/pom/testdata/soft-requirement-with-transitive-dependencies/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>soft-transitive</artifactId>
+    <version>1.0.0</version>
+
+    <name>soft-transitive</name>
+    <description>Example</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency2</artifactId>
+            <version>2.3.4</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Description
In Maven, an order of `<dependencies>` is critical. If the order is updated, the resolved dependencies will be different. The current implementation uses a map that doesn't keep order. This PR fixes the issue.

- dependency-a
  - dependency-c v1
- dependency-b
  - dependency-c v2

If the soft requirement is used, `v1` should be used for `dependency-c`.

- dependency-b
  - dependency-c v2
- dependency-a
  - dependency-c v1

On the other hand, `v2` should be used in the above case.

## Issue
https://github.com/aquasecurity/trivy/issues/1728

## Reference
https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification