### PR TITLE
feat(jar): Allow setting Maven Central URL using environment variable

### DIFF
--- a/pkg/java/jar/parse.go
+++ b/pkg/java/jar/parse.go
@@ -81,8 +81,15 @@ func Parse(r dio.ReadSeekerAt, size int64, opts ...Option) ([]types.Library, err
 	retryClient.RetryMax = 5
 	client := retryClient.StandardClient()
 
+	// attempt to read the maven central api url from os environment, if it's
+	// not set use the default
+	mavenURL, ok := os.LookupEnv("MAVEN_CENTRAL_URL")
+	if !ok {
+		mavenURL = baseURL
+	}
+
 	c := conf{
-		baseURL:    baseURL,
+		baseURL:    mavenURL,
 		httpClient: client,
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
This should allow setting the URL which go-dep-parser uses to contact Maven Central when parsing JAR dependencies. It's an attempt to provide a solution for https://github.com/aquasecurity/trivy/issues/1869. I haven't developed in go before so not sure if this is a bad attempt or not :sweat_smile: 