### PR TITLE
Fix merge multiple pom imports

### DIFF
--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -267,7 +267,7 @@ func (p parser) dependencyManagement(deps []pomDependency, props properties) map
 			art := newArtifact(d.GroupID, d.ArtifactID, d.Version, props)
 			result, err := p.resolve(art)
 			if err == nil {
-				depManagement = p.mergeDependencyManagement(depManagement, result.dependencyManagement)
+				depManagement = p.mergeDependencyManagement(result.dependencyManagement, depManagement)
 			}
 			continue
 		}

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -229,6 +229,21 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "import multiple dependencyManagement",
+			inputFile: filepath.Join("testdata", "import-dependency-management-multiple", "pom.xml"),
+			local:     true,
+			want: []types.Library{
+				{
+					Name:    "com.example:import",
+					Version: "2.0.0",
+				},
+				{
+					Name:    "org.example:example-api",
+					Version: "1.7.30",
+				},
+			},
+		},
+		{
 			name:      "exclusions",
 			inputFile: filepath.Join("testdata", "exclusions", "pom.xml"),
 			local:     true,

--- a/pkg/java/pom/testdata/import-dependency-management-multiple/pom.xml
+++ b/pkg/java/pom/testdata/import-dependency-management-multiple/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>import</artifactId>
+    <version>2.0.0</version>
+
+    <packaging>pom</packaging>
+    <name>import</name>
+    <description>Import dependencyManagement</description>
+
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-dependency-management</artifactId>
+                <version>2.2.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-dependency-management2</artifactId>
+                <version>1.1.1</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/java/pom/testdata/repository/org/example/example-dependency-management2/1.1.1/example-dependency-management2-1.1.1.pom
+++ b/pkg/java/pom/testdata/repository/org/example/example-dependency-management2/1.1.1/example-dependency-management2-1.1.1.pom
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-dependency-management2</artifactId>
+    <version>1.1.1</version>
+
+    <packaging>pom</packaging>
+    <name>Example API Dependency Management</name>
+    <description>The example API</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>


### PR DESCRIPTION
In maven, a definition of a dependency will not override by any other definition.

```
% mvn -s testdata/conf/settings.xml -f testdata/import-dependency-management-multiple dependency:tree  | grep example-api
[ERROR] Failed to execute goal on project import: Could not resolve dependencies for project com.example:import:pom:2.0.0: org.example:example-api:jar:1.7.30 was not found in https://repo.maven.apache.org/maven2 during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
```

Previously, go-dep-parser detects version 1.1.1, since its defined in the second import bom.

See also: https://github.com/aquasecurity/trivy/issues/1943