### PR TITLE
fix: fixed panic for gomod without version

### DIFF
--- a/pkg/golang/mod/parse.go
+++ b/pkg/golang/mod/parse.go
@@ -26,7 +26,10 @@ func Parse(r io.Reader) ([]types.Library, error) {
 		return nil, xerrors.Errorf("go.mod parse error: %w", err)
 	}
 
-	skipIndirect := lessThan117(modFileParsed.Go.Version)
+	skipIndirect := true
+	if modFileParsed.Go != nil { // Old go.mod file may not include the go version. Go version for these files  is less than 1.17
+		skipIndirect = lessThan117(modFileParsed.Go.Version)
+	}
 
 	for _, require := range modFileParsed.Require {
 		// Skip indirect dependencies less than Go 1.17

--- a/pkg/golang/mod/parse_test.go
+++ b/pkg/golang/mod/parse_test.go
@@ -23,6 +23,11 @@ func TestParse(t *testing.T) {
 			want: GoModNormal,
 		},
 		{
+			name: "without go version",
+			file: "testdata/no-go-version/go.mod",
+			want: GoModNoGoVersion,
+		},
+		{
 			name: "replace",
 			file: "testdata/replaced/go.mod",
 			want: GoModReplaced,

--- a/pkg/golang/mod/parse_testcase.go
+++ b/pkg/golang/mod/parse_testcase.go
@@ -52,4 +52,9 @@ var (
 	GoMod116 = []types.Library{
 		{Name: "github.com/aquasecurity/go-dep-parser", Version: "0.0.0-20211224170007-df43bca6b6ff", Indirect: false},
 	}
+
+	// execute go mod tidy in no-go-version folder
+	GoModNoGoVersion = []types.Library{
+		{Name: "github.com/aquasecurity/go-dep-parser", Version: "0.0.0-20211224170007-df43bca6b6ff", Indirect: false},
+	}
 )

--- a/pkg/golang/mod/testdata/no-go-version/go.mod
+++ b/pkg/golang/mod/testdata/no-go-version/go.mod
@@ -1,0 +1,3 @@
+module github.com/org/repo
+
+require github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff

--- a/pkg/golang/mod/testdata/no-go-version/main.go
+++ b/pkg/golang/mod/testdata/no-go-version/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+
+	"github.com/aquasecurity/go-dep-parser/pkg/golang/mod"
+)
+
+func main() {
+	if _, err := mod.Parse(nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Description
We have panic, if go.mod doesn't contain go version.:
```
➜  cat go.mod 
module github.com/aquasecurity/fanal                                          
➜  trivy fs .
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16ee9bc]

goroutine 38 [running]:
github.com/aquasecurity/go-dep-parser/pkg/golang/mod.Parse({0x2224da0, 0xc000a5a2e8})
	/home/runner/go/pkg/mod/github.com/aquasecurity/go-dep-parser@v0.0.0-20220412145205-d0501f906d90/pkg/golang/mod/parse.go:29 +0x13c
github.com/aquasecurity/fanal/analyzer/language.Analyze({0x1d16263, 0x5}, {0xc000fbb9c0, 0x6}, {0x2224da0?, 0xc000a5a2e8?}, 0x0?)
	/home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/analyzer/language/analyze.go:16 +0x68
github.com/aquasecurity/fanal/analyzer/language/golang/mod.gomodAnalyzer.Analyze({}, {0x1cdeac0?, 0x0?}, {{0x7fff5fb923b6, 0x1}, {0xc000fbb9c0, 0x6}, {0x2235ed8, 0xc000fb9450}, {0x222fdf8, ...}, ...})
	/home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/analyzer/language/golang/mod/mod.go:39 +0xc5
github.com/aquasecurity/fanal/analyzer.AnalyzerGroup.AnalyzeFile.func1({0x2231258, 0x31df0a0}, {0x2232c28?, 0xc000a5a2e8})
	/home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/analyzer/analyzer.go:258 +0x253
created by github.com/aquasecurity/fanal/analyzer.AnalyzerGroup.AnalyzeFile
	/home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/analyzer/analyzer.go:253 +0x3d8
```
added check for `go.mod` files without go version.
These files will be checked as `less than v1.17`.

## Related issues
- aquasecurity/trivy/issues/2024
