### PR TITLE
fix(gemspec): split licenses by ', '

### DIFF
--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -112,6 +112,21 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "transitive parents",
+			inputFile: filepath.Join("testdata", "transitive-parents", "base", "pom.xml"),
+			local:     true,
+			want: []types.Library{
+				{
+					Name:    "com.example:child",
+					Version: "3.0.0",
+				},
+				{
+					Name:    "org.example:example-api",
+					Version: "1.7.30",
+				},
+			},
+		},
+		{
 			name:      "parent relativePath",
 			inputFile: filepath.Join("testdata", "parent-relative-path", "pom.xml"),
 			local:     true,

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -112,21 +112,6 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
-			name:      "transitive parents",
-			inputFile: filepath.Join("testdata", "transitive-parents", "base", "pom.xml"),
-			local:     true,
-			want: []types.Library{
-				{
-					Name:    "com.example:child",
-					Version: "3.0.0",
-				},
-				{
-					Name:    "org.example:example-api",
-					Version: "1.7.30",
-				},
-			},
-		},
-		{
 			name:      "parent relativePath",
 			inputFile: filepath.Join("testdata", "parent-relative-path", "pom.xml"),
 			local:     true,

--- a/pkg/ruby/gemspec/parse.go
+++ b/pkg/ruby/gemspec/parse.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode"
 
 	"golang.org/x/xerrors"
 
@@ -39,7 +38,7 @@ var (
 	// Capture the value of "licenses"
 	// e.g. s.license = ["MIT".freeze, "BSDL".freeze]
 	//      => "MIT".freeze, "BSDL".freeze
-	licensesRegexp = regexp.MustCompile(`\.licenses\s*=\s*\[(?P<licenses>.+)\]`)
+	licensesRegexp = regexp.MustCompile(`\.licenses\s*=\s*\[(?P<licenses>.+)]`)
 )
 
 type Parser struct{}
@@ -121,9 +120,7 @@ func trim(s string) string {
 func parseLicenses(s string) string {
 	// e.g. `"Ruby".freeze, "BSDL".freeze`
 	//      => {"\"Ruby\".freeze", "\"BSDL\".freeze"}
-	ss := strings.FieldsFunc(s, func(r rune) bool {
-		return unicode.IsSpace(r) || r == ','
-	})
+	ss := strings.Split(s, ", ")
 
 	// e.g. {"\"Ruby\".freeze", "\"BSDL\".freeze"}
 	//      => {"Ruby", "BSDL"}

--- a/pkg/ruby/gemspec/parse.go
+++ b/pkg/ruby/gemspec/parse.go
@@ -113,6 +113,7 @@ func findSubString(re *regexp.Regexp, line, name string) string {
 // Trim single quotes, double quotes and ".freeze"
 // e.g. "async".freeze => async
 func trim(s string) string {
+	s = strings.TrimSpace(s)
 	s = strings.TrimSuffix(s, ".freeze")
 	return strings.Trim(s, `'"`)
 }
@@ -120,7 +121,7 @@ func trim(s string) string {
 func parseLicenses(s string) string {
 	// e.g. `"Ruby".freeze, "BSDL".freeze`
 	//      => {"\"Ruby\".freeze", "\"BSDL\".freeze"}
-	ss := strings.Split(s, ", ")
+	ss := strings.Split(s, ",")
 
 	// e.g. {"\"Ruby\".freeze", "\"BSDL\".freeze"}
 	//      => {"Ruby", "BSDL"}

--- a/pkg/ruby/gemspec/parse.go
+++ b/pkg/ruby/gemspec/parse.go
@@ -38,7 +38,7 @@ var (
 	// Capture the value of "licenses"
 	// e.g. s.license = ["MIT".freeze, "BSDL".freeze]
 	//      => "MIT".freeze, "BSDL".freeze
-	licensesRegexp = regexp.MustCompile(`\.licenses\s*=\s*\[(?P<licenses>.+)]`)
+	licensesRegexp = regexp.MustCompile(`\.licenses\s*=\s*\[(?P<licenses>.+)\]`)
 )
 
 type Parser struct{}

--- a/pkg/ruby/gemspec/testdata/multiple_licenses.gemspec
+++ b/pkg/ruby/gemspec/testdata/multiple_licenses.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = "test-unit (Test::Unit) is unit testing framework for Ruby, based on xUnit\nprinciples. These were originally designed by Kent Beck, creator of extreme\nprogramming software development methodology, for Smalltalk's SUnit. It allows\nwriting tests, checking results and automated testing in Ruby.\n".freeze
   s.email = ["kou@cozmixng.org".freeze, "yoshihara@clear-code.com".freeze]
   s.homepage = "http://test-unit.github.io/".freeze
-  s.licenses = ["Ruby".freeze, "BSDL".freeze, "PSFL".freeze]
+  s.licenses = ["Ruby".freeze,"BSDL".freeze, "PSFL".freeze]
   s.rubygems_version = "3.2.22".freeze
   s.summary = "An xUnit family unit testing framework for Ruby.".freeze
 


### PR DESCRIPTION
## Description
There are licenses like `"Apache 2.0".freeze`. 
We incorrectly split this license as `Apache` and `2.0.freeze`.

Changed separator to `,`.