### PR TITLE
revert references in package.json

### DIFF
--- a/pkg/nodejs/packagejson/parse.go
+++ b/pkg/nodejs/packagejson/parse.go
@@ -8,46 +8,15 @@ import (
 	"golang.org/x/xerrors"
 )
 
-type packageRef struct {
-	Type string
-	Url  string
-}
 type packageJSON struct {
-	Name       string      `json:"name"`
-	Version    string      `json:"version"`
-	License    interface{} `json:"license"`
-	Homepage   string      `json:"homepage,omitempty"`
-	Repository packageRef  `json:"repository,omitempty"`
-	Bugs       packageRef  `json:"bugs,omitempty"`
-	Funding    packageRef  `json:"funding,omitempty"`
+	Name    string      `json:"name"`
+	Version string      `json:"version"`
+	License interface{} `json:"license"`
 }
 type Parser struct{}
 
 func NewParser() types.Parser {
 	return &Parser{}
-}
-
-func (p *Parser) GetExternalRefs(packageJson packageJSON) []types.ExternalRef {
-	externalRefs := []types.ExternalRef{}
-	if packageJson.Homepage != "" {
-		externalRefs = append(externalRefs, types.ExternalRef{Type: types.RefWebsite, URL: packageJson.Homepage})
-	}
-	switch v := packageJson.License.(type) {
-	case map[string]interface{}:
-		if licenseUrl, ok := v["url"]; ok {
-			externalRefs = append(externalRefs, types.ExternalRef{Type: types.RefLicense, URL: licenseUrl.(string)})
-		}
-	}
-
-	if (packageJson.Repository != packageRef{}) {
-		externalRefs = append(externalRefs, types.ExternalRef{Type: types.RefVCS, URL: packageJson.Repository.Url})
-	}
-
-	if (packageJson.Bugs != packageRef{}) {
-		externalRefs = append(externalRefs, types.ExternalRef{Type: types.RefIssueTracker, URL: packageJson.Bugs.Url})
-	}
-
-	return externalRefs
 }
 
 func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency, error) {
@@ -62,10 +31,9 @@ func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency,
 	}
 
 	return []types.Library{{
-		Name:               data.Name,
-		Version:            data.Version,
-		License:            parseLicense(data.License),
-		ExternalReferences: p.GetExternalRefs(data),
+		Name:    data.Name,
+		Version: data.Version,
+		License: parseLicense(data.License),
 	}}, nil, nil
 }
 

--- a/pkg/nodejs/packagejson/parse_test.go
+++ b/pkg/nodejs/packagejson/parse_test.go
@@ -3,7 +3,6 @@ package packagejson_test
 import (
 	"os"
 	"path"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,10 +28,9 @@ func TestParse(t *testing.T) {
 			// npm install --save promise jquery
 			// npm ls | grep -E -o "\S+@\S+" | awk -F@ 'NR>0 {printf("{\""$1"\", \""$2"\"},\n")}'
 			want: []types.Library{{
-				Name:               "bootstrap",
-				Version:            "5.0.2",
-				License:            "MIT",
-				ExternalReferences: []types.ExternalRef{{Type: types.RefWebsite, URL: "https://getbootstrap.com/"}, {Type: types.RefVCS, URL: "git+https://github.com/twbs/bootstrap.git"}, {Type: types.RefIssueTracker, URL: "https://github.com/twbs/bootstrap/issues"}},
+				Name:    "bootstrap",
+				Version: "5.0.2",
+				License: "MIT",
 			}},
 			wantErr: "",
 		},
@@ -40,10 +38,9 @@ func TestParse(t *testing.T) {
 			name:      "happy path - legacy license",
 			inputFile: "testdata/legacy_package.json",
 			want: []types.Library{{
-				Name:               "angular",
-				Version:            "4.1.2",
-				License:            "ISC",
-				ExternalReferences: []types.ExternalRef{{Type: types.RefWebsite, URL: "https://getbootstrap.com/"}, {Type: types.RefVCS, URL: "git+https://github.com/twbs/bootstrap.git"}, {Type: types.RefIssueTracker, URL: "https://github.com/twbs/bootstrap/issues"}, {Type: types.RefLicense, URL: "https://opensource.org/licenses/ISC"}},
+				Name:    "angular",
+				Version: "4.1.2",
+				License: "ISC",
 			}},
 			wantErr: "",
 		},
@@ -72,22 +69,8 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			for _, lib := range v.want {
-				sortExternalRefs(lib.ExternalReferences)
-			}
-
-			for _, lib := range got {
-				sortExternalRefs(lib.ExternalReferences)
-			}
-
 			require.NoError(t, err)
 			assert.Equal(t, v.want, got)
 		})
 	}
-}
-
-func sortExternalRefs(refs []types.ExternalRef) {
-	sort.Slice(refs, func(i, j int) bool {
-		return refs[i].URL < refs[j].URL
-	})
 }


### PR DESCRIPTION
## Description
This change introduced a bug. Seems like `repository` can be string. We need to revert it for now and take a further investigation later.

```
2022-08-15T19:24:58.636+0600    DEBUG   Analysis error: unable to parse var/www/html/package.json: JSON decode error: json: cannot unmarshal string into Go struct field packageJSON.repository of type packagejson.packageRef
2022-08-15T19:25:00.080+0600    INFO    Number of language-specific files: 3
2022-08-15T19:25:00.081+0600    INFO    Detecting composer vulnerabilities...
2022-08-15T19:25:00.082+0600    DEBUG   Detecting library vulnerabilities, type: composer, path: var/www/html/composer.lock
2022-08-15T19:25:00.084+0600    DEBUG   Detecting library vulnerabilities, type: composer, path: var/www/html/vendor/pragmarx/google2fa-qrcode/composer.lock
```

## Related PRs
https://github.com/aquasecurity/go-dep-parser/pull/111