### PR TITLE
fix(rust): add skipped package IDs

### DIFF
--- a/pkg/rust/binary/parse.go
+++ b/pkg/rust/binary/parse.go
@@ -58,7 +58,7 @@ func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency,
 			for _, dep_idx := range pkg.Dependencies {
 				dep := info.Packages[dep_idx]
 				if dep.Kind == rustaudit.Runtime {
-					childDeps = append(childDeps, pkgID)
+					childDeps = append(childDeps, utils.PackageID(dep.Name, dep.Version))
 				}
 			}
 			if len(childDeps) > 0 {

--- a/pkg/rust/binary/parse.go
+++ b/pkg/rust/binary/parse.go
@@ -46,7 +46,9 @@ func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency,
 	var deps []types.Dependency
 	for _, pkg := range info.Packages {
 		if pkg.Kind == rustaudit.Runtime {
+			pkgID := utils.PackageID(pkg.Name, pkg.Version)
 			libs = append(libs, types.Library{
+				ID:       pkgID,
 				Name:     pkg.Name,
 				Version:  pkg.Version,
 				Indirect: !pkg.Root,
@@ -56,11 +58,11 @@ func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency,
 			for _, dep_idx := range pkg.Dependencies {
 				dep := info.Packages[dep_idx]
 				if dep.Kind == rustaudit.Runtime {
-					childDeps = append(childDeps, utils.PackageID(dep.Name, dep.Version))
+					childDeps = append(childDeps, pkgID)
 				}
 			}
 			if len(childDeps) > 0 {
-				deps = append(deps, types.Dependency{ID: utils.PackageID(pkg.Name, pkg.Version), DependsOn: childDeps})
+				deps = append(deps, types.Dependency{ID: pkgID, DependsOn: childDeps})
 			}
 		}
 	}

--- a/pkg/rust/binary/parse_test.go
+++ b/pkg/rust/binary/parse_test.go
@@ -16,11 +16,13 @@ import (
 var (
 	libs = []types.Library{
 		{
+			ID:       "crate_with_features@0.1.0",
 			Name:     "crate_with_features",
 			Version:  "0.1.0",
 			Indirect: false,
 		},
 		{
+			ID:       "library_crate@0.1.0",
 			Name:     "library_crate",
 			Version:  "0.1.0",
 			Indirect: true,


### PR DESCRIPTION
There was skipped package IDs, so `trivy` can't match dependencies