### PR TITLE
Distinguish p.offline message from errors

### DIFF
--- a/pkg/java/jar/parse.go
+++ b/pkg/java/jar/parse.go
@@ -163,7 +163,7 @@ func (p *Parser) parseArtifact(fileName string, size int64, r dio.ReadSeekerAt) 
 	if p.offline {
 		// In offline mode, we will not check if the artifact information is correct.
 		if !manifestProps.valid() {
-			log.Logger.Debugw("Unable to identify POM in offline mode", zap.String("file", fileName))
+			log.Logger.Debugw("Won't try to identify POM while in offline mode", zap.String("file", fileName))
 			return libs, nil, nil
 		}
 		return append(libs, manifestProps.library()), nil, nil


### PR DESCRIPTION
Hello GitLab support here 👋 

We've received a customer report wondering about the `Unable to identify POM in offline mode` debug messages.

The wording `Unable` implies that some attempt failed, but is this the case in offline mode?

The comment on L164 states "we will not check". Should this be clarified in the error message?

Cheers!