### PR TITLE
fix(java): use fields of dependency from dependencyManagement from upper pom.xml to parse deps

### DIFF
--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -254,7 +254,7 @@ func (p *parser) analyze(pom *pom, exclusions map[string]struct{}, depManagement
 	depManagement = p.mergeDependencyManagements(depManagementFromUpperPoms, depManagement, parent.dependencyManagement)
 
 	// Merge dependencies. Child dependencies must be preferred than parent dependencies.
-	deps := p.parseDependencies(pom.content.Dependencies.Dependency, props, depManagement, exclusions)
+	deps := p.parseDependencies(pom.content.Dependencies.Dependency, props, depManagement, depManagementFromUpperPoms, exclusions)
 	deps = p.mergeDependencies(parent.dependencies, deps, exclusions)
 
 	return analysisResult{
@@ -271,7 +271,7 @@ func (p parser) dependencyManagement(deps []pomDependency, props properties) map
 	depManagement := map[string]pomDependency{}
 	for _, d := range deps {
 		// Evaluate variables
-		d = d.Resolve(props, nil)
+		d = d.Resolve(props, nil, nil)
 
 		// https://howtodoinjava.com/maven/maven-dependency-scopes/#import
 		if d.Scope == "import" {
@@ -299,11 +299,11 @@ func (p parser) mergeDependencyManagements(depManagements ...map[string]pomDepen
 }
 
 func (p parser) parseDependencies(deps []pomDependency, props map[string]string, depManagement map[string]pomDependency,
-	exclusions map[string]struct{}) []artifact {
+	depManagementFromUpperPoms map[string]pomDependency, exclusions map[string]struct{}) []artifact {
 	var dependencies []artifact
 	for _, d := range deps {
 		// Resolve dependencies
-		d = d.Resolve(props, depManagement)
+		d = d.Resolve(props, depManagement, depManagementFromUpperPoms)
 
 		if (d.Scope != "" && d.Scope != "compile") || d.Optional {
 			continue

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -328,6 +328,31 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "overwrite artifact version from upper pom dependencyManagement",
+			inputFile: filepath.Join("testdata", "upper-pom-dep-management", "pom.xml"),
+			local:     true,
+			want: []types.Library{
+				{
+					Name:    "com.example:upper-pom-dep-management",
+					Version: "1.0.0",
+				},
+				{
+					Name:    "org.example:example-api",
+					Version: "2.0.0",
+				},
+				// dependency version is taken from `com.example:upper-pom-dep-management` from dependencyManagement
+				// not from `com.example:example-nested` from `com.example:example-nested`
+				{
+					Name:    "org.example:example-dependency",
+					Version: "1.2.4",
+				},
+				{
+					Name:    "org.example:example-nested",
+					Version: "3.3.3",
+				},
+			},
+		},
+		{
 			name:      "parent not found",
 			inputFile: filepath.Join("testdata", "not-found-parent", "pom.xml"),
 			local:     true,

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -167,7 +167,7 @@ func (d pomDependency) Name() string {
 }
 
 // Resolve evaluates variables in the dependency and inherit some fields from dependencyManagement to the dependency.
-func (d pomDependency) Resolve(props map[string]string, depManagement map[string]pomDependency) pomDependency {
+func (d pomDependency) Resolve(props map[string]string, depManagement map[string]pomDependency, depManagementFromUpperPoms map[string]pomDependency) pomDependency {
 	// Evaluate variables
 	dep := pomDependency{
 		Text:       d.Text,
@@ -179,8 +179,26 @@ func (d pomDependency) Resolve(props map[string]string, depManagement map[string
 		Exclusions: d.Exclusions,
 	}
 
+	// if this dependency is in the upper pom.xml in `dependencyManagement`
+	// then we need to take non-empty fields from the upper pom.xml
+	if managed, ok := depManagementFromUpperPoms[d.Name()]; ok { // dependencyManagement from upper pom.xml
+		if managed.Version != "" {
+			dep.Version = evaluateVariable(managed.Version, props, nil)
+		}
+		if managed.Scope != "" {
+			dep.Scope = evaluateVariable(managed.Scope, props, nil)
+		}
+		if managed.Optional {
+			dep.Optional = managed.Optional
+		}
+		if len(managed.Exclusions) != 0 {
+			dep.Exclusions = managed.Exclusions
+		}
+		return dep
+	}
+
 	// Inherit version, scope and optional from dependencyManagement
-	if managed, ok := depManagement[d.Name()]; ok {
+	if managed, ok := depManagement[d.Name()]; ok { // dependencyManagement from parent
 		if dep.Version == "" {
 			dep.Version = evaluateVariable(managed.Version, props, nil)
 		}

--- a/pkg/java/pom/testdata/upper-pom-dep-management/pom.xml
+++ b/pkg/java/pom/testdata/upper-pom-dep-management/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>upper-pom-dep-management</artifactId>
+    <version>1.0.0</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-dependency</artifactId>
+                <version>1.2.4</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested</artifactId>
+            <version>3.3.3</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
## Description
Non-empty fields of dependency(if child pom.xml has this dependency) from `DependencyManagement` from upper pom.xml have higher priority then dependency fields from `Dependency` from child pom.xml.

Example:
Base pom.xml:
```xml
    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>org.jetbrains</groupId>
                <artifactId>markdown-jvm</artifactId>
                <version>0.2.2</version>
            </dependency>
        </dependencies>
    </dependencyManagement>
    <dependencies>
        <dependency>
                <groupId>org.jetbrains.dokka</groupId>
                <artifactId>dokka-core</artifactId>
                <version>1.7.10</version>
        </dependency>
    </dependencies>           
```

[org.jetbrains.dokka:dokka-core v1.7.10](https://repo1.maven.org/maven2/org/jetbrains/dokka/dokka-core/1.7.10/dokka-core-1.7.10.pom):
```xml
<dependencies>
    <dependency>
        <groupId>org.jetbrains</groupId>
        <artifactId>markdown-jvm</artifactId>
        <version>0.2.4</version>
        <scope>compile</scope>
    </dependency>
</dependencies>
```

Result dependency:

- mvn:
```zsh
➜  mvn dependency:tree | grep markdown
[INFO]    +- org.jetbrains:markdown-jvm:jar:0.2.2:compile
```
- trivy results:

  -  **before** changes:
  ```zsh
  ➜ trivy fs -f json --list-all-pkgs ./pom.xml | grep "markdown" -A 2
           "Name": "org.jetbrains:markdown-jvm",
            "Version": "0.2.4",
            "Layer": {}
  ```
  - **after** changes:
  ```zsh
  ➜ ./trivy fs -f json --list-all-pkgs ./pom.xml | grep "markdown" -A 2
            "Name": "org.jetbrains:markdown-jvm",
            "Version": "0.2.2",
            "Layer": {}
  ```


## Related issues:
- aquasecurity/trivy/issues/2935