### PR TITLE
refactor(jar): write debug message when wrong inner jar is found

### DIFF
--- a/pkg/java/jar/parse.go
+++ b/pkg/java/jar/parse.go
@@ -148,7 +148,9 @@ func (p *Parser) parseArtifact(fileName string, size int64, r dio.ReadSeekerAt) 
 		case isArtifact(fileInJar.Name):
 			innerLibs, _, err := p.parseInnerJar(fileInJar) //TODO process inner deps
 			if err != nil {
-				return nil, nil, xerrors.Errorf("failed to parse %s: %w", fileInJar.Name, err)
+				log.Logger.Debugf("failed to parse %s: %s", fileInJar.Name, err)
+				continue
+				//return nil, nil, xerrors.Errorf("failed to parse %s: %w", fileInJar.Name, err)
 			}
 			libs = append(libs, innerLibs...)
 		}

--- a/pkg/java/jar/parse.go
+++ b/pkg/java/jar/parse.go
@@ -150,7 +150,6 @@ func (p *Parser) parseArtifact(fileName string, size int64, r dio.ReadSeekerAt) 
 			if err != nil {
 				log.Logger.Debugf("failed to parse %s: %s", fileInJar.Name, err)
 				continue
-				//return nil, nil, xerrors.Errorf("failed to parse %s: %w", fileInJar.Name, err)
 			}
 			libs = append(libs, innerLibs...)
 		}

--- a/pkg/java/jar/parse.go
+++ b/pkg/java/jar/parse.go
@@ -148,7 +148,7 @@ func (p *Parser) parseArtifact(fileName string, size int64, r dio.ReadSeekerAt) 
 		case isArtifact(fileInJar.Name):
 			innerLibs, _, err := p.parseInnerJar(fileInJar) //TODO process inner deps
 			if err != nil {
-				log.Logger.Debugf("failed to parse %s: %s", fileInJar.Name, err)
+				log.Logger.Debugf("Failed to parse %s: %s", fileInJar.Name, err)
 				continue
 			}
 			libs = append(libs, innerLibs...)


### PR DESCRIPTION
## Description
When we found wrong inner jar - we don't need to stop parsing jar.
We need to create debug message and continue parsing.

## Related issues
- aquasecurity/trivy/issues/2952