### PR TITLE
feat: add kas parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/liamg/jfather v0.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/whilp/git-urls v1.0.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/text v0.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/pkg/git/kas/parse.go
+++ b/pkg/git/kas/parse.go
@@ -1,0 +1,78 @@
+package kas
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/xerrors"
+	"gopkg.in/yaml.v3"
+
+	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	giturls "github.com/whilp/git-urls"
+
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+	"github.com/aquasecurity/go-dep-parser/pkg/utils"
+)
+
+type Repo struct {
+	Url     string `yaml:"url,omitempty"`
+	RefSpec string `yaml:"refspec,omitempty"`
+}
+
+type KasFile struct {
+	Repos map[string]Repo `yaml:"repos,omitempty"`
+}
+
+type Parser struct{}
+
+func NewParser() types.Parser {
+	return &Parser{}
+}
+
+func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency, error) {
+	var kasFile KasFile
+	decoder := yaml.NewDecoder(r)
+	err := decoder.Decode(&kasFile)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("decode error: %w", err)
+	}
+
+	libs, deps := p.parse(&kasFile)
+
+	return libs, deps, nil
+}
+
+func (p *Parser) parse(kasFile *KasFile) ([]types.Library, []types.Dependency) {
+	var libs []types.Library
+
+	for _, repo := range kasFile.Repos {
+		name := getRepoNamefromUri(repo.Url)
+		if name == "" || repo.Url == "" {
+			continue
+		}
+
+		version := repo.RefSpec
+		if version == "" {
+			version = "latest"
+		}
+
+		libs = append(libs, types.Library{
+			ID:      utils.PackageID(name, version),
+			Name:    name,
+			Version: version,
+		})
+	}
+
+	return libs, nil
+}
+
+func getRepoNamefromUri(rawUri string) string {
+	uri, err := giturls.Parse(rawUri)
+	if err != nil {
+		return ""
+	}
+
+	name := strings.TrimSuffix(uri.Path, ".git")
+	name = strings.TrimLeft(name, "/")
+	return fmt.Sprintf("%s/%s", uri.Host, name)
+}

--- a/pkg/git/kas/parse_test.go
+++ b/pkg/git/kas/parse_test.go
@@ -1,0 +1,52 @@
+package kas
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+)
+
+func TestParse(t *testing.T) {
+	vectors := []struct {
+		file string
+		want []types.Library
+	}{
+		{
+			file: "testdata/kas.yml",
+			want: kasRepo,
+		},
+		{
+			file: "testdata/kas-no-refspec.yml",
+			want: kasRepoLatest,
+		},
+		{
+			file: "testdata/kas-git-url.yml",
+			want: kasRepoGitUrl,
+		},
+		{
+			file: "testdata/kas-git-url.yml",
+			want: kasRepoSshUrl,
+		},
+		{
+			file: "testdata/kas-multiple-repos.yml",
+			want: kasRepos,
+		},
+	}
+
+	for _, v := range vectors {
+		t.Run(path.Base(v.file), func(t *testing.T) {
+			f, err := os.Open(v.file)
+			require.NoError(t, err)
+
+			got, _, err := NewParser().Parse(f)
+			require.NoError(t, err)
+
+			assert.Equal(t, v.want, got)
+		})
+	}
+}

--- a/pkg/git/kas/parse_testcase.go
+++ b/pkg/git/kas/parse_testcase.go
@@ -1,0 +1,50 @@
+package kas
+
+import "github.com/aquasecurity/go-dep-parser/pkg/types"
+
+var (
+	kasRepo = []types.Library{
+		{
+			ID:      "github.com/org/kas@1.0.0",
+			Name:    "github.com/org/kas",
+			Version: "1.0.0",
+		},
+	}
+
+	kasRepoLatest = []types.Library{
+		{
+			ID:      "github.com/org/kas@latest",
+			Name:    "github.com/org/kas",
+			Version: "latest",
+		},
+	}
+
+	kasRepoGitUrl = []types.Library{
+		{
+			ID:      "github.com/org/kas@1.0.0",
+			Name:    "github.com/org/kas",
+			Version: "1.0.0",
+		},
+	}
+
+	kasRepoSshUrl = []types.Library{
+		{
+			ID:      "github.com/org/kas@1.0.0",
+			Name:    "github.com/org/kas",
+			Version: "1.0.0",
+		},
+	}
+
+	kasRepos = []types.Library{
+		{
+			ID:      "github.com/org/kas@1.0.0",
+			Name:    "github.com/org/kas",
+			Version: "1.0.0",
+		},
+		{
+			ID:      "github.com/user/repo@2.0.0",
+			Name:    "github.com/user/repo",
+			Version: "2.0.0",
+		},
+	}
+)

--- a/pkg/git/kas/testdata/kas-git-url.yml
+++ b/pkg/git/kas/testdata/kas-git-url.yml
@@ -1,0 +1,12 @@
+header:
+  version: 11
+  includes:
+    - repo: externalrepo
+      file: tests/test_layers/test.yml
+
+repos:
+  this:
+
+  externalrepo:
+    url: git@github.com:org/kas.git
+    refspec: 1.0.0

--- a/pkg/git/kas/testdata/kas-multiple-repos.yml
+++ b/pkg/git/kas/testdata/kas-multiple-repos.yml
@@ -1,0 +1,16 @@
+header:
+  version: 11
+  includes:
+    - repo: externalrepo
+      file: tests/test_layers/test.yml
+
+repos:
+  this:
+
+  externalrepo:
+    url: https://github.com/org/kas.git
+    refspec: 1.0.0
+
+  userrepo:
+    url: https://github.com/user/repo.git
+    refspec: 2.0.0

--- a/pkg/git/kas/testdata/kas-no-refspec.yml
+++ b/pkg/git/kas/testdata/kas-no-refspec.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+  includes:
+    - repo: externalrepo
+      file: tests/test_layers/test.yml
+
+repos:
+  this:
+
+  externalrepo:
+    url: https://github.com/org/kas.git

--- a/pkg/git/kas/testdata/kas-ssh-url.yml
+++ b/pkg/git/kas/testdata/kas-ssh-url.yml
@@ -1,0 +1,12 @@
+header:
+  version: 11
+  includes:
+    - repo: externalrepo
+      file: tests/test_layers/test.yml
+
+repos:
+  this:
+
+  externalrepo:
+    url: ssh://git@github.com/org/kas.git
+    refspec: 1.0.0

--- a/pkg/git/kas/testdata/kas.yml
+++ b/pkg/git/kas/testdata/kas.yml
@@ -1,0 +1,12 @@
+header:
+  version: 11
+  includes:
+    - repo: externalrepo
+      file: tests/test_layers/test.yml
+
+repos:
+  this:
+
+  externalrepo:
+    url: https://github.com/org/kas.git
+    refspec: 1.0.0


### PR DESCRIPTION
This is part 1 of adding a few git-based dependencies to trivy - see https://github.com/aquasecurity/trivy/issues/3067. There is more context there, I'm not sure if this is the right place for a git-based parser so I'm happy to make changes, even if this code should live in another repo etc :)

An example real life kas file:
https://github.com/siemens/meta-iot2050/blob/master/kas/iot2050.yml

This PR is largely based on the pnpm parser PR as that had a similar yaml parser, though kas config files are even simpler.
I'll follow up on the trivy side with an analyzer, if this makes sense.