### PR TITLE
feat: add gitlab-ci include parser

### DIFF
--- a/pkg/gitlab/include/parse.go
+++ b/pkg/gitlab/include/parse.go
@@ -1,0 +1,64 @@
+package include
+
+import (
+	"golang.org/x/xerrors"
+	"gopkg.in/yaml.v3"
+
+	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+	"github.com/aquasecurity/go-dep-parser/pkg/utils"
+)
+
+type Include struct {
+	Project string `yaml:"project,omitempty"`
+	Ref     string `yaml:"ref,omitempty"`
+}
+
+type GitlabCiFile struct {
+	Includes []Include `yaml:"include,omitempty"`
+}
+
+type Parser struct{}
+
+func NewParser() types.Parser {
+	return &Parser{}
+}
+
+func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency, error) {
+	var gitlabCiFile GitlabCiFile
+	decoder := yaml.NewDecoder(r)
+	err := decoder.Decode(&gitlabCiFile)
+	if err != nil {
+		// Currently only parses data when we can unmarshal from array project includes
+		// See https://docs.gitlab.com/ee/ci/yaml/includes.html for other options
+		return nil, nil, xerrors.Errorf("failed to parse gitlab-ci file: %w", err)
+	}
+
+	libs, deps := p.parse(&gitlabCiFile)
+
+	return libs, deps, nil
+}
+
+func (p *Parser) parse(gitlabCiFile *GitlabCiFile) ([]types.Library, []types.Dependency) {
+	var libs []types.Library
+
+	for _, include := range gitlabCiFile.Includes {
+		name := include.Project
+		if name == "" {
+			continue
+		}
+
+		version := include.Ref
+		if version == "" {
+			version = "latest"
+		}
+
+		libs = append(libs, types.Library{
+			ID:      utils.PackageID(name, version),
+			Name:    name,
+			Version: version,
+		})
+	}
+
+	return libs, nil
+}

--- a/pkg/gitlab/include/parse_test.go
+++ b/pkg/gitlab/include/parse_test.go
@@ -1,0 +1,40 @@
+package include
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+)
+
+func TestParse(t *testing.T) {
+	vectors := []struct {
+		file string
+		want []types.Library
+	}{
+		{
+			file: "testdata/.gitlab-ci.yml",
+			want: gitlabCiInclude,
+		},
+		{
+			file: "testdata/no-ref.gitlab-ci.yml",
+			want: gitlabCiIncludeLatest,
+		},
+	}
+
+	for _, v := range vectors {
+		t.Run(path.Base(v.file), func(t *testing.T) {
+			f, err := os.Open(v.file)
+			require.NoError(t, err)
+
+			got, _, err := NewParser().Parse(f)
+			require.NoError(t, err)
+
+			assert.Equal(t, v.want, got)
+		})
+	}
+}

--- a/pkg/gitlab/include/parse_testcase.go
+++ b/pkg/gitlab/include/parse_testcase.go
@@ -1,0 +1,21 @@
+package include
+
+import "github.com/aquasecurity/go-dep-parser/pkg/types"
+
+var (
+	gitlabCiInclude = []types.Library{
+		{
+			ID:      "my-group/my-project@1.0.0",
+			Name:    "my-group/my-project",
+			Version: "1.0.0",
+		},
+	}
+
+	gitlabCiIncludeLatest = []types.Library{
+		{
+			ID:      "my-group/my-project@latest",
+			Name:    "my-group/my-project",
+			Version: "latest",
+		},
+	}
+)

--- a/pkg/gitlab/include/testdata/.gitlab-ci.yml
+++ b/pkg/gitlab/include/testdata/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: my-group/my-project
+    ref: 1.0.0
+    file: /templates/.gitlab-ci-template.yml

--- a/pkg/gitlab/include/testdata/no-ref.gitlab-ci.yml
+++ b/pkg/gitlab/include/testdata/no-ref.gitlab-ci.yml
@@ -1,0 +1,3 @@
+include:
+  - project: my-group/my-project
+    file: /templates/.gitlab-ci-template.yml


### PR DESCRIPTION
Very similar to https://github.com/aquasecurity/go-dep-parser/pull/143, this is part 2 of adding a few git-based dependencies to trivy - see https://github.com/aquasecurity/trivy/issues/3067 for more context.

This adds basic support for gitlab-ci includes, mostly for discussion in https://github.com/aquasecurity/trivy/issues/3067. I'll extend/adapt this based on feedback and discussions in the issue, and first see if it makes sense to add it here :)