### PR TITLE
fix(go): skip dep without Path for go-binaries

### DIFF
--- a/pkg/golang/binary/parse.go
+++ b/pkg/golang/binary/parse.go
@@ -45,6 +45,13 @@ func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency,
 	libs := make([]types.Library, 0, len(info.Deps))
 
 	for _, dep := range info.Deps {
+		// binaries with old go version may incorrectly add module in Deps
+		// In this case Path == "", Version == "Devel"
+		// we need to skip this
+		if dep.Path == "" {
+			continue
+		}
+
 		mod := dep
 		if dep.Replace != nil {
 			mod = dep.Replace


### PR DESCRIPTION
## Description
Binaries with old go version may incorrectly add module in Deps.
e.g.:
![Screenshot from 2022-12-01 14-00-51](https://user-images.githubusercontent.com/91113035/204999661-6ad4dddf-8b6d-4562-bd6c-aa70b11af3ee.png)
Skip dependencies without `Path`.

## Related Issues
- aquasecurity/trivy/issues/3237

