### PR TITLE
fix(yarn): yarn parser error handling

### DIFF
--- a/pkg/nodejs/yarn/parse.go
+++ b/pkg/nodejs/yarn/parse.go
@@ -205,7 +205,7 @@ func parseBlock(block []byte, lineNum int) (lib Library, deps []string, newLine 
 			if patterns == nil || !validProtocol(protocol) {
 				skipBlock = true
 				if !ignoreProtocol(protocol) {
-					err = xerrors.Errorf("failed to parse package patterns")
+					return Library{}, nil, -1,  xerrors.Errorf("failed to parse package patterns")
 				}
 				continue
 			} else {

--- a/pkg/nodejs/yarn/parse.go
+++ b/pkg/nodejs/yarn/parse.go
@@ -105,10 +105,18 @@ func getDependency(target string) (name, version string, err error) {
 	return capture[1], capture[2], nil
 }
 
-func validProtocol(protocol string) (valid bool) {
+func validProtocol(protocol string) bool {
 	switch protocol {
 	// only scan npm packages
 	case "npm", "":
+		return true
+	}
+	return false
+}
+
+func ignoreProtocol(protocol string) bool {
+	switch protocol {
+	case "workspace", "patch":
 		return true
 	}
 	return false
@@ -196,7 +204,9 @@ func parseBlock(block []byte, lineNum int) (lib Library, deps []string, newLine 
 		if name, protocol, patterns, patternErr := parsePackagePatterns(line); patternErr == nil {
 			if patterns == nil || !validProtocol(protocol) {
 				skipBlock = true
-				err = xerrors.Errorf("failed to parse package patterns")
+				if !ignoreProtocol(protocol) {
+					err = xerrors.Errorf("failed to parse package patterns")
+				}
 				continue
 			} else {
 				lib.Patterns = patterns
@@ -211,7 +221,7 @@ func parseBlock(block []byte, lineNum int) (lib Library, deps []string, newLine 
 		EndLine:   scanner.LineNum(lineNum),
 	}
 
-	if scanErr := scanner.Err(); err != scanErr {
+	if scanErr := scanner.Err(); scanErr != nil {
 		err = scanErr
 	}
 

--- a/pkg/nodejs/yarn/parse_test.go
+++ b/pkg/nodejs/yarn/parse_test.go
@@ -251,6 +251,7 @@ func TestParse(t *testing.T) {
 		file     string // Test input file
 		want     []types.Library
 		wantDeps []types.Dependency
+		wantErr  bool
 	}{
 		{
 			name:     "normal",
@@ -310,6 +311,12 @@ func TestParse(t *testing.T) {
 			want:     yarnV2Many,
 			wantDeps: yarnV2ManyDeps,
 		},
+		{
+			name:     "bad yarn file",
+			file:     "testdata/bad_yarn.lock",
+			wantErr:  true,
+			wantDeps: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -318,6 +325,12 @@ func TestParse(t *testing.T) {
 			require.NoError(t, err)
 
 			got, deps, err := NewParser().Parse(f)
+
+			if tt.wantErr {
+				require.NotNil(t, err)
+				return
+			}
+
 			require.NoError(t, err)
 
 			sortLibs(got)

--- a/pkg/nodejs/yarn/testdata/bad_yarn.lock
+++ b/pkg/nodejs/yarn/testdata/bad_yarn.lock
@@ -1,0 +1,2 @@
+  asap@unsupported:~2.0.6:
+  version "2.0.6"


### PR DESCRIPTION
Found an issue when failed to parse a dependency block:
[This](https://github.com/aquasecurity/go-dep-parser/blob/main/pkg/nodejs/yarn/parse.go#L214) line causes the scanner to return a result altho it should've thrown an error.