### PR TITLE
fix(pnpm): add support for parsing packages from repositories

### DIFF
--- a/pkg/nodejs/pnpm/parse.go
+++ b/pkg/nodejs/pnpm/parse.go
@@ -101,9 +101,13 @@ func isIndirectLib(name string, directDeps map[string]string) bool {
 }
 
 func getPackageNameAndVersion(pkg string) (string, string) {
-	idx := strings.LastIndex(pkg, "/")
-	name := pkg[1:idx]
-	version := pkg[idx+1:]
+	// possible 2 package formats:
+	// relative path: `/<pkg_name>/<pkg_version>` e.g. /foo/1.0.0
+	// absolute path: `<registry_url>/<pkg_name>/<pkg_version>` e.g. registry.node-modules.io/foo/1.0.0
+	// https://github.com/pnpm/spec/blob/master/lockfile/5.2.md#packages
+	s := strings.Split(pkg, "/")
+	name := s[len(s)-2]
+	version := s[len(s)-1]
 
 	return name, version
 }

--- a/pkg/nodejs/pnpm/parse_test.go
+++ b/pkg/nodejs/pnpm/parse_test.go
@@ -79,3 +79,34 @@ func sortLibs(libs []types.Library) {
 		return ret < 0
 	})
 }
+
+func TestGetPackageNameAndVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		pkg         string
+		wantName    string
+		wantVersion string
+	}{
+		{
+			name:        "relative path",
+			pkg:         "/lodash/4.17.10",
+			wantName:    "lodash",
+			wantVersion: "4.17.10",
+		},
+		{
+			name:        "private registry",
+			pkg:         "registry.npmjs.org/lodash/4.17.10",
+			wantName:    "lodash",
+			wantVersion: "4.17.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotVersion := getPackageNameAndVersion(tt.pkg)
+			assert.Equal(t, tt.wantName, gotName)
+			assert.Equal(t, tt.wantVersion, gotVersion)
+		})
+
+	}
+}


### PR DESCRIPTION
## Description 
There are `<registry_url>/<pkg_name>/<pkg_version>` packages.(https://github.com/pnpm/spec/blob/master/lockfile/5.2.md#packages)
Update parsing for these packages.