### PR TITLE
refactor: use warning for invalid protocols in yarn.lock

### DIFF
--- a/pkg/nodejs/yarn/parse.go
+++ b/pkg/nodejs/yarn/parse.go
@@ -208,7 +208,7 @@ func parseBlock(block []byte, lineNum int) (lib Library, deps []string, newLine 
 				if !ignoreProtocol(protocol) {
 					// we need to calculate the last line of the block in order to correctly determine the line numbers of the next blocks
 					// store the error. we will handle it later
-					err = xerrors.Errorf("failed to parse package pattern: '%s', unknown protocol: '%s'", line, protocol)
+					err = xerrors.Errorf("unknown protocol: '%s', line: %s", protocol, line)
 					continue
 				}
 				continue
@@ -223,7 +223,7 @@ func parseBlock(block []byte, lineNum int) (lib Library, deps []string, newLine 
 	// in case an unsupported protocol is detected
 	// show warning and continue parsing
 	if err != nil {
-		log.Logger.Warnf(err.Error())
+		log.Logger.Warnf("Yarn protocol error: %s", err)
 		return Library{}, nil, scanner.LineNum(lineNum), nil
 	}
 

--- a/pkg/nodejs/yarn/parse.go
+++ b/pkg/nodejs/yarn/parse.go
@@ -3,6 +3,7 @@ package yarn
 import (
 	"bufio"
 	"bytes"
+	"github.com/aquasecurity/go-dep-parser/pkg/log"
 	"io"
 	"regexp"
 	"strings"
@@ -205,7 +206,10 @@ func parseBlock(block []byte, lineNum int) (lib Library, deps []string, newLine 
 			if patterns == nil || !validProtocol(protocol) {
 				skipBlock = true
 				if !ignoreProtocol(protocol) {
-					return Library{}, nil, -1, xerrors.Errorf("failed to parse package pattern: '%s', unknown protocol: '%s'", line, protocol)
+					// we need to calculate the last line of the block in order to correctly determine the line numbers of the next blocks
+					// store the error. we will handle it later
+					err = xerrors.Errorf("failed to parse package pattern: '%s', unknown protocol: '%s'", line, protocol)
+					continue
 				}
 				continue
 			} else {
@@ -214,6 +218,13 @@ func parseBlock(block []byte, lineNum int) (lib Library, deps []string, newLine 
 				continue
 			}
 		}
+	}
+
+	// in case an unsupported protocol is detected
+	// show warning and continue parsing
+	if err != nil {
+		log.Logger.Warnf(err.Error())
+		return Library{}, nil, scanner.LineNum(lineNum), nil
 	}
 
 	lib.Location = types.Location{

--- a/pkg/nodejs/yarn/parse_test.go
+++ b/pkg/nodejs/yarn/parse_test.go
@@ -251,7 +251,6 @@ func TestParse(t *testing.T) {
 		file     string // Test input file
 		want     []types.Library
 		wantDeps []types.Dependency
-		wantErr  bool
 	}{
 		{
 			name:     "normal",
@@ -322,10 +321,9 @@ func TestParse(t *testing.T) {
 			file: "testdata/yarn_with_git.lock",
 		},
 		{
-			name:     "bad yarn file",
-			file:     "testdata/bad_yarn.lock",
-			wantErr:  true,
-			wantDeps: nil,
+			name: "yarn file with bad protocol",
+			file: "testdata/yarn_with_bad_protocol.lock",
+			want: yarnBadProtocol,
 		},
 	}
 
@@ -335,12 +333,6 @@ func TestParse(t *testing.T) {
 			require.NoError(t, err)
 
 			got, deps, err := NewParser().Parse(f)
-
-			if tt.wantErr {
-				require.NotNil(t, err)
-				return
-			}
-
 			require.NoError(t, err)
 
 			sortLibs(got)

--- a/pkg/nodejs/yarn/parse_testcase.go
+++ b/pkg/nodejs/yarn/parse_testcase.go
@@ -15867,4 +15867,8 @@ var (
 	yarnWithNpm = []types.Library{
 		{ID: "jquery@3.6.0", Name: "jquery", Version: "3.6.0", Locations: []types.Location{{StartLine: 1, EndLine: 4}}},
 	}
+
+	yarnBadProtocol = []types.Library{
+		{ID: "jquery@3.4.1", Name: "jquery", Version: "3.4.1", Locations: []types.Location{{StartLine: 4, EndLine: 7}}},
+	}
 )

--- a/pkg/nodejs/yarn/testdata/bad_yarn.lock
+++ b/pkg/nodejs/yarn/testdata/bad_yarn.lock
@@ -1,2 +1,0 @@
-  asap@unsupported:~2.0.6:
-  version "2.0.6"

--- a/pkg/nodejs/yarn/testdata/yarn_with_bad_protocol.lock
+++ b/pkg/nodejs/yarn/testdata/yarn_with_bad_protocol.lock
@@ -1,0 +1,7 @@
+asap@unsupported:~2.0.6:
+  version "2.0.6"
+
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==


### PR DESCRIPTION
## Description
We currently stop parsing if invalid protocol is found.
We need to show warning and continue parsing in these cases.