### PR TITLE
refactor: don't return error for package.json without version/name

### DIFF
--- a/pkg/nodejs/packagejson/parse.go
+++ b/pkg/nodejs/packagejson/parse.go
@@ -35,8 +35,10 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 		return Package{}, xerrors.Errorf("JSON decode error: %w", err)
 	}
 
+	// Name and version fields are optional
+	// https://docs.npmjs.com/cli/v9/configuring-npm/package-json#name
 	if pkgJSON.Name == "" || pkgJSON.Version == "" {
-		return Package{}, xerrors.New("unable to parse package.json")
+		return Package{}, nil
 	}
 
 	return Package{

--- a/pkg/nodejs/packagejson/parse_test.go
+++ b/pkg/nodejs/packagejson/parse_test.go
@@ -20,7 +20,7 @@ func TestParse(t *testing.T) {
 		wantErr   string
 	}{
 		{
-			name:      "happypath",
+			name:      "happy path",
 			inputFile: "testdata/package.json",
 
 			// docker run --name composer --rm -it node:12-alpine sh
@@ -54,6 +54,11 @@ func TestParse(t *testing.T) {
 				},
 				Dependencies: map[string]string{},
 			},
+		},
+		{
+			name:      "happy path - version doesn't exist",
+			inputFile: "testdata/without_version_package.json",
+			want:      packagejson.Package{},
 		},
 		{
 			name:      "sad path",

--- a/pkg/nodejs/packagejson/testdata/without_version_package.json
+++ b/pkg/nodejs/packagejson/testdata/without_version_package.json
@@ -1,0 +1,4 @@
+
+{
+  "name": "angular"
+}


### PR DESCRIPTION
## Description
`Name` and `Version` fields are optional for `package.json` - https://docs.npmjs.com/cli/v9/configuring-npm/package-json#name
We don't need to return error for files without `name` or `version`.

## Related Issues
- aquasecurity/trivy/issues/4054