### PR TITLE
fix(pom): skipping missing modules

### DIFF
--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -156,7 +156,8 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 		for _, relativePath := range result.modules {
 			moduleArtifact, err := p.parseModule(result.filePath, relativePath)
 			if err != nil {
-				return nil, nil, xerrors.Errorf("module error (%s): %w", relativePath, err)
+				log.Logger.Debugf("Unable to parse %q module: %s", result.filePath, err)
+				continue
 			}
 
 			queue.enqueue(moduleArtifact)

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -442,10 +442,15 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
-			name:      "module not found",
+			name:      "module not found - unable to parse module",
 			inputFile: filepath.Join("testdata", "not-found-module", "pom.xml"),
 			local:     true,
-			wantErr:   "stat testdata/not-found-module/module: no such file or directory",
+			want: []types.Library{
+				{
+					Name:    "com.example:aggregation",
+					Version: "1.0.0",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Following the issue described at https://github.com/aquasecurity/trivy/issues/3747 where for the case where you run :
trivy fs pom.xml 
with the following pom.xml:

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
    <dependencies>
        <dependency>
            <groupId>org.apache.hive</groupId>
            <artifactId>hive-exec</artifactId>
            <version>2.3.3</version>
        </dependency>
    </dependencies>
</project>
```

you get zero results due to a parser error of one of the dependencies in the pom.
The following PR suggests skipping those missing modules.