### PR TITLE
fix(pip): remove extras from lines of requirement.txt files

### DIFF
--- a/pkg/python/pip/parse.go
+++ b/pkg/python/pip/parse.go
@@ -14,6 +14,8 @@ const (
 	commentMarker string = "#"
 	endColon      string = ";"
 	hashMarker    string = "--"
+	startExtras   string = "["
+	endExtras     string = "]"
 )
 
 type Parser struct{}
@@ -30,6 +32,7 @@ func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency,
 		line := scanner.Text()
 		line = strings.ReplaceAll(line, " ", "")
 		line = strings.ReplaceAll(line, `\`, "")
+		line = removeExtras(line)
 		line = rStripByKey(line, commentMarker)
 		line = rStripByKey(line, endColon)
 		line = rStripByKey(line, hashMarker)
@@ -51,6 +54,15 @@ func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency,
 func rStripByKey(line string, key string) string {
 	if pos := strings.Index(line, key); pos >= 0 {
 		line = strings.TrimRightFunc((line)[:pos], unicode.IsSpace)
+	}
+	return line
+}
+
+func removeExtras(line string) string {
+	startIndex := strings.Index(line, startExtras)
+	endIndex := strings.Index(line, endExtras) + 1
+	if startIndex != -1 && endIndex != -1 {
+		line = line[:startIndex] + line[endIndex:]
 	}
 	return line
 }

--- a/pkg/python/pip/parse.go
+++ b/pkg/python/pip/parse.go
@@ -2,7 +2,6 @@ package pip
 
 import (
 	"bufio"
-	"github.com/aquasecurity/go-dep-parser/pkg/log"
 	"strings"
 	"unicode"
 
@@ -63,7 +62,6 @@ func removeExtras(line string) string {
 	startIndex := strings.Index(line, startExtras)
 	endIndex := strings.Index(line, endExtras) + 1
 	if startIndex != -1 && endIndex != -1 {
-		log.Logger.Debugf("unable to get name and version for extras of %q. Run `pip3 freeze > requirements.txt` to update file and get this dependency", line)
 		line = line[:startIndex] + line[endIndex:]
 	}
 	return line

--- a/pkg/python/pip/parse.go
+++ b/pkg/python/pip/parse.go
@@ -2,6 +2,7 @@ package pip
 
 import (
 	"bufio"
+	"github.com/aquasecurity/go-dep-parser/pkg/log"
 	"strings"
 	"unicode"
 
@@ -62,6 +63,7 @@ func removeExtras(line string) string {
 	startIndex := strings.Index(line, startExtras)
 	endIndex := strings.Index(line, endExtras) + 1
 	if startIndex != -1 && endIndex != -1 {
+		log.Logger.Debugf("unable to get name and version for extras of %q. Run `pip3 freeze > requirements.txt` to update file and get this dependency", line)
 		line = line[:startIndex] + line[endIndex:]
 	}
 	return line

--- a/pkg/python/pip/parse_test.go
+++ b/pkg/python/pip/parse_test.go
@@ -44,6 +44,10 @@ func TestParse(t *testing.T) {
 			file: "testdata/requirements_hyphens.txt",
 			want: requirementsHyphens,
 		},
+		{
+			file: "testdata/requirement_exstras.txt",
+			want: requirementsExtras,
+		},
 	}
 
 	for _, v := range vectors {

--- a/pkg/python/pip/parse_testcase.go
+++ b/pkg/python/pip/parse_testcase.go
@@ -44,4 +44,9 @@ var (
 		{Name: "oauth2-client", Version: "4.0.0"},
 		{Name: "python-gitlab", Version: "2.0.0"},
 	}
+
+	requirementsExtras = []types.Library{
+		{Name: "pyjwt", Version: "2.1.0"},
+		{Name: "celery", Version: "4.4.7"},
+	}
 )

--- a/pkg/python/pip/testdata/requirement_exstras.txt
+++ b/pkg/python/pip/testdata/requirement_exstras.txt
@@ -1,0 +1,2 @@
+pyjwt[crypto]==2.1.0
+celery[redis, pytest]==4.4.7


### PR DESCRIPTION
## Description
`requirement.txt` can contain extras. e.g. `pyjwt[crypto]==2.1.0`
We need to find dependency name correctly.