### PR TITLE
fix(jar): use slash as separator for any OS for inner jars

### DIFF
--- a/pkg/java/jar/parse.go
+++ b/pkg/java/jar/parse.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/xerrors"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -193,10 +194,10 @@ func (p *Parser) parseInnerJar(zf *zip.File, rootPath string) ([]types.Library, 
 	}
 
 	// build full path to inner jar
-	path := filepath.Join(rootPath, zf.Name)
+	fullPath := path.Join(rootPath, zf.Name)
 
 	// Parse jar/war/ear recursively
-	innerLibs, innerDeps, err := p.parseArtifact(path, int64(zf.UncompressedSize64), f)
+	innerLibs, innerDeps, err := p.parseArtifact(fullPath, int64(zf.UncompressedSize64), f)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to parse %s: %w", zf.Name, err)
 	}


### PR DESCRIPTION
## Desciption
The inner separator in ZIP files is always slashed even though it is created on Windows.
https://github.com/aquasecurity/trivy/pull/3992#discussion_r1174786549