### PR TITLE
fix(pom): add support of `*` for exclusions

### DIFF
--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -316,6 +316,29 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "exclusions with wildcards",
+			inputFile: filepath.Join("testdata", "wildcard-exclusions", "pom.xml"),
+			local:     true,
+			want: []types.Library{
+				{
+					Name:    "com.example:wildcard-exclusions",
+					Version: "4.0.0",
+				},
+				{
+					Name:    "org.example:example-dependency",
+					Version: "1.2.3",
+				},
+				{
+					Name:    "org.example:example-dependency2",
+					Version: "2.3.4",
+				},
+				{
+					Name:    "org.example:example-nested",
+					Version: "3.3.3",
+				},
+			},
+		},
+		{
 			name:      "multi module",
 			inputFile: filepath.Join("testdata", "multi-module", "pom.xml"),
 			local:     true,

--- a/pkg/java/pom/testdata/wildcard-exclusions/pom.xml
+++ b/pkg/java/pom/testdata/wildcard-exclusions/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>wildcard-exclusions</artifactId>
+    <version>4.0.0</version>
+
+    <packaging>pom</packaging>
+    <name>wildcard-exclusions</name>
+    <description>Exclusions with wildcards</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>1.2.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>example-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency2</artifactId>
+            <version>2.3.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested</artifactId>
+            <version>3.3.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.example</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Description
`Maven` supports wildcards in `Exclusion` fields - https://maven.apache.org/pom.html#exclusions.

But i have playing with it and looks like `Maven` only supports `*` value. So i added logic only for `*` value.
For example this doesn't work:
``` xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>

    <groupId>example</groupId>
    <artifactId>trivy-test</artifactId>
    <version>1.0-SNAPSHOT</version>

    <dependencies>
        <dependency>
            <groupId>org.springframework.ws</groupId>
            <artifactId>spring-ws-core</artifactId>
            <version>3.0.1.RELEASE</version>
            <exclusions>
                <exclusion>
                    <groupId>org.*</groupId>
                    <artifactId>*</artifactId>
                </exclusion>
            </exclusions>
        </dependency>
    </dependencies>
</project>
```
Maven result:
```bash
➜  4051 mvn dependency:tree
...
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ trivy-test ---
[INFO] example:trivy-test:jar:1.0-SNAPSHOT
[INFO] \- org.springframework.ws:spring-ws-core:jar:3.0.1.RELEASE:compile
[INFO]    +- org.springframework.ws:spring-xml:jar:3.0.1.RELEASE:compile
[INFO]    |  \- org.springframework:spring-context:jar:5.0.4.RELEASE:compile
[INFO]    +- org.springframework:spring-aop:jar:5.0.4.RELEASE:compile
[INFO]    +- org.springframework:spring-beans:jar:5.0.4.RELEASE:compile
[INFO]    +- org.springframework:spring-oxm:jar:5.0.4.RELEASE:compile
[INFO]    +- org.springframework:spring-web:jar:5.0.4.RELEASE:compile
[INFO]    +- org.springframework:spring-webmvc:jar:5.0.4.RELEASE:compile
[INFO]    |  \- org.springframework:spring-expression:jar:5.0.4.RELEASE:compile
[INFO]    +- commons-logging:commons-logging:jar:1.2:compile
[INFO]    +- commons-io:commons-io:jar:2.5:compile
[INFO]    \- org.springframework:spring-core:jar:5.0.4.RELEASE:compile
[INFO]       \- org.springframework:spring-jcl:jar:5.0.4.RELEASE:compile
...
```

## Related Issues
- aquasecurity/trivy/issues/4051