### PR TITLE
fix(pom): don't skip parent when version is property

### DIFF
--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -392,7 +392,7 @@ func (p *parser) parseParent(currentPath string, parent pomParent) (analysisResu
 	// Pass nil properties so that variables in <parent> are not evaluated.
 	target := newArtifact(parent.GroupId, parent.ArtifactId, parent.Version, "", nil)
 	// if version is property (e.g. ${revision}) - we still need to parse this pom
-	if target.IsEmpty() && !versionIsProperty(parent.Version) {
+	if target.IsEmpty() && !isProperty(parent.Version) {
 		return analysisResult{}, nil
 	}
 	log.Logger.Debugf("Start parent: %s", target.String())

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -391,7 +391,8 @@ func excludeDep(exclusions map[string]struct{}, art artifact) bool {
 func (p *parser) parseParent(currentPath string, parent pomParent) (analysisResult, error) {
 	// Pass nil properties so that variables in <parent> are not evaluated.
 	target := newArtifact(parent.GroupId, parent.ArtifactId, parent.Version, "", nil)
-	if target.IsEmpty() {
+	// if version is property (e.g. ${revision}) - we still need to parse this pom
+	if target.IsEmpty() && !versionIsProperty(parent.Version) {
 		return analysisResult{}, nil
 	}
 	log.Logger.Debugf("Start parent: %s", target.String())

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -202,6 +202,21 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "parent version in property",
+			inputFile: filepath.Join("testdata", "parent-version-is-property", "child", "pom.xml"),
+			local:     false,
+			want: []types.Library{
+				{
+					Name:    "com.example:child",
+					Version: "1.0.0-SNAPSHOT",
+				},
+				{
+					Name:    "org.example:example-api",
+					Version: "1.1.1",
+				},
+			},
+		},
+		{
 			name:      "parent in a remote repository",
 			inputFile: filepath.Join("testdata", "parent-remote-repository", "pom.xml"),
 			local:     true,

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -26,7 +26,7 @@ func (p *pom) inherit(result analysisResult) {
 	p.content.GroupId = art.GroupID
 	p.content.ArtifactId = art.ArtifactID
 
-	if versionIsProperty(art.Version.String()) {
+	if isProperty(art.Version.String()) {
 		p.content.Version = evaluateVariable(art.Version.String(), p.content.Properties, nil)
 	} else {
 		p.content.Version = art.Version.String()

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -25,7 +25,12 @@ func (p *pom) inherit(result analysisResult) {
 
 	p.content.GroupId = art.GroupID
 	p.content.ArtifactId = art.ArtifactID
-	p.content.Version = art.Version.String()
+
+	if versionIsProperty(art.Version.String()) {
+		p.content.Version = evaluateVariable(art.Version.String(), p.content.Properties, nil)
+	} else {
+		p.content.Version = art.Version.String()
+	}
 }
 
 func (p pom) properties() properties {

--- a/pkg/java/pom/testdata/parent-version-is-property/child/pom.xml
+++ b/pkg/java/pom/testdata/parent-version-is-property/child/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>child</artifactId>
+
+    <name>child</name>
+    <version>${revision}</version>
+    <description>Child</description>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/java/pom/testdata/parent-version-is-property/pom.xml
+++ b/pkg/java/pom/testdata/parent-version-is-property/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>${revision}</version>
+
+    <packaging>pom</packaging>
+    <name>parent</name>
+    <description>Parent</description>
+
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pkg/java/pom/utils.go
+++ b/pkg/java/pom/utils.go
@@ -13,7 +13,7 @@ func isDirectory(path string) (bool, error) {
 	return fileInfo.IsDir(), err
 }
 
-func versionIsProperty(version string) bool {
+func isProperty(version string) bool {
 	if version != "" && strings.HasPrefix(version, "${") && strings.HasSuffix(version, "}") {
 		return true
 	}

--- a/pkg/java/pom/utils.go
+++ b/pkg/java/pom/utils.go
@@ -1,6 +1,9 @@
 package pom
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 func isDirectory(path string) (bool, error) {
 	fileInfo, err := os.Stat(path)
@@ -8,4 +11,11 @@ func isDirectory(path string) (bool, error) {
 		return false, err
 	}
 	return fileInfo.IsDir(), err
+}
+
+func versionIsProperty(version string) bool {
+	if version != "" && strings.HasPrefix(version, "${") && strings.HasSuffix(version, "}") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
## Description
There is case when parent version is property (e.g. `${revision}`). We need to try find of this parent by relative path.

More information [here](https://github.com/aquasecurity/trivy/discussions/4670)