### PR TITLE
feat(pom.xml): add `dependsOn` and `Indirect` support

### DIFF
--- a/pkg/java/pom/artifact.go
+++ b/pkg/java/pom/artifact.go
@@ -25,6 +25,7 @@ type artifact struct {
 
 	Module bool
 	Root   bool
+	Direct bool
 }
 
 func newArtifact(groupID, artifactID, version string, licenses []string, props map[string]string) artifact {

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -3,7 +3,6 @@ package pom
 import (
 	"encoding/xml"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
 	"net/url"
@@ -119,7 +118,6 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 		rootDepManagement []pomDependency
 		uniqArtifacts     = map[string]artifact{}
 		uniqDeps          = map[string][]string{}
-		savedDeps         []string
 	)
 
 	// Iterate direct and transitive dependencies
@@ -194,18 +192,10 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 
 			// save only dependency names
 			// version will be determined later
-			dependsOn := lo.FilterMap(result.dependencies, func(a artifact, _ int) (string, bool) {
-				return a.Name(), !slices.Contains(savedDeps, a.Name())
+			dependsOn := lo.Map(result.dependencies, func(a artifact, _ int) string {
+				return a.Name()
 			})
-			//dependsOn := lo.Map(result.dependencies, func(a artifact, _ int) string {
-			//	return a.Name()
-			//})
 			uniqDeps[packageID(art.Name(), art.Version.String())] = dependsOn
-			// mvn only takes top dependencies
-			// this is needed to reproduce mvn logic
-			// take a look at `soft requirement`, `soft requirement with transitive dependencies`
-			// and `hard requirement for the specified version` tests
-			savedDeps = append(savedDeps, dependsOn...)
 		}
 	}
 

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -199,19 +199,17 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 		}
 	}
 
-	// Convert to []types.Library
+	// Convert to []types.Library and []types.Dependency
 	for name, art := range uniqArtifacts {
-		libs = append(libs, types.Library{
+		lib := types.Library{
 			ID:       packageID(name, art.Version.String()),
 			Name:     name,
 			Version:  art.Version.String(),
 			License:  art.JoinLicenses(),
 			Indirect: !art.Direct,
-		})
-	}
+		}
+		libs = append(libs, lib)
 
-	// Convert to []types.Dependencies
-	for _, lib := range libs {
 		// Convert dependency names into dependency IDs
 		dependsOn := lo.FilterMap(uniqDeps[lib.ID], func(dependOnName string, _ int) (string, bool) {
 			ver := depVersion(dependOnName, uniqArtifacts)

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -195,7 +195,7 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 			dependsOn := lo.Map(result.dependencies, func(a artifact, _ int) string {
 				return a.Name()
 			})
-			uniqDeps[packageID(art.Name(), art.Version.String())] = dependsOn
+			uniqDeps[art.Name()] = dependsOn
 		}
 	}
 
@@ -211,8 +211,11 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 	}
 
 	// Convert to []types.Dependencies
-	for pkgID, dependsOn := range uniqDeps {
-		// get ID from uniqArtifacts for dependsOn
+	for pkgName, dependsOn := range uniqDeps {
+		// uniqDeps contains only dependency names
+		// get pkgID from uniqArtifacts
+		pkgID := packageID(pkgName, depVersion(pkgName, uniqArtifacts))
+		// get depID from uniqArtifacts for dependsOn
 		dependsOn = lo.FilterMap(dependsOn, func(dependOnName string, _ int) (string, bool) {
 			ver := depVersion(dependOnName, uniqArtifacts)
 			return packageID(dependOnName, ver), ver != ""

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -195,7 +195,7 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 			dependsOn := lo.Map(result.dependencies, func(a artifact, _ int) string {
 				return a.Name()
 			})
-			uniqDeps[art.Name()] = dependsOn
+			uniqDeps[packageID(art.Name(), art.Version.String())] = dependsOn
 		}
 	}
 
@@ -211,12 +211,9 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 	}
 
 	// Convert to []types.Dependencies
-	for pkgName, dependsOn := range uniqDeps {
-		// uniqDeps contains only dependency names
-		// get pkgID from uniqArtifacts
-		pkgID := packageID(pkgName, depVersion(pkgName, uniqArtifacts))
-		// get depID from uniqArtifacts for dependsOn
-		dependsOn = lo.FilterMap(dependsOn, func(dependOnName string, _ int) (string, bool) {
+	for _, lib := range libs {
+		// Convert dependency names into dependency IDs
+		dependsOn := lo.FilterMap(uniqDeps[lib.ID], func(dependOnName string, _ int) (string, bool) {
 			ver := depVersion(dependOnName, uniqArtifacts)
 			return packageID(dependOnName, ver), ver != ""
 		})
@@ -224,7 +221,7 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 		sort.Strings(dependsOn)
 		if len(dependsOn) > 0 {
 			deps = append(deps, types.Dependency{
-				ID:        pkgID,
+				ID:        lib.ID,
 				DependsOn: dependsOn,
 			})
 		}

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -3,6 +3,7 @@ package pom
 import (
 	"encoding/xml"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,7 +16,6 @@ import (
 	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 	"golang.org/x/net/html/charset"
 	"golang.org/x/xerrors"
 
@@ -197,7 +197,10 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 			dependsOn := lo.FilterMap(result.dependencies, func(a artifact, _ int) (string, bool) {
 				return a.Name(), !slices.Contains(savedDeps, a.Name())
 			})
-			uniqDeps[PackageID(art.Name(), art.Version.String())] = dependsOn
+			//dependsOn := lo.Map(result.dependencies, func(a artifact, _ int) string {
+			//	return a.Name()
+			//})
+			uniqDeps[packageID(art.Name(), art.Version.String())] = dependsOn
 			// mvn only takes top dependencies
 			// this is needed to reproduce mvn logic
 			// take a look at `soft requirement`, `soft requirement with transitive dependencies`
@@ -209,7 +212,7 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 	// Convert to []types.Library
 	for name, art := range uniqArtifacts {
 		libs = append(libs, types.Library{
-			ID:       PackageID(name, art.Version.String()),
+			ID:       packageID(name, art.Version.String()),
 			Name:     name,
 			Version:  art.Version.String(),
 			License:  art.JoinLicenses(),
@@ -222,7 +225,7 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 		// get ID from uniqArtifacts for dependsOn
 		dependsOn = lo.FilterMap(dependsOn, func(dependOnName string, _ int) (string, bool) {
 			ver := depVersion(dependOnName, uniqArtifacts)
-			return PackageID(dependOnName, ver), ver != ""
+			return packageID(dependOnName, ver), ver != ""
 		})
 
 		sort.Strings(dependsOn)

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -197,7 +197,7 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 			dependsOn := lo.FilterMap(result.dependencies, func(a artifact, _ int) (string, bool) {
 				return a.Name(), !slices.Contains(savedDeps, a.Name())
 			})
-			uniqDeps[art.Name()] = dependsOn
+			uniqDeps[PackageID(art.Name(), art.Version.String())] = dependsOn
 			// mvn only takes top dependencies
 			// this is needed to reproduce mvn logic
 			// take a look at `soft requirement`, `soft requirement with transitive dependencies`
@@ -218,11 +218,7 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 	}
 
 	// Convert to []types.Dependencies
-	for name, dependsOn := range uniqDeps {
-		// uniqDeps contains only dependency names
-		// get ID from uniqArtifacts
-		id := PackageID(name, depVersion(name, uniqArtifacts))
-
+	for pkgID, dependsOn := range uniqDeps {
 		// get ID from uniqArtifacts for dependsOn
 		dependsOn = lo.FilterMap(dependsOn, func(dependOnName string, _ int) (string, bool) {
 			ver := depVersion(dependOnName, uniqArtifacts)
@@ -232,7 +228,7 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 		sort.Strings(dependsOn)
 		if len(dependsOn) > 0 {
 			deps = append(deps, types.Dependency{
-				ID:        id,
+				ID:        pkgID,
 				DependsOn: dependsOn,
 			})
 		}

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +21,7 @@ func TestPom_Parse(t *testing.T) {
 		local     bool
 		offline   bool
 		want      []types.Library
+		wantDeps  []types.Dependency
 		wantErr   string
 	}{
 		{
@@ -30,13 +30,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:happy:1.0.0",
 					Name:    "com.example:happy",
 					Version: "1.0.0",
 					License: "BSD-3-Clause",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:happy:1.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -46,13 +56,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     false,
 			want: []types.Library{
 				{
+					ID:      "com.example:happy:1.0.0",
 					Name:    "com.example:happy",
 					Version: "1.0.0",
 					License: "BSD-3-Clause",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:happy:1.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -63,6 +83,7 @@ func TestPom_Parse(t *testing.T) {
 			offline:   true,
 			want: []types.Library{
 				{
+					ID:      "org.example:example-offline:2.3.4",
 					Name:    "org.example:example-offline",
 					Version: "2.3.4",
 				},
@@ -74,13 +95,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:child:1.0.0",
 					Name:    "com.example:child",
 					Version: "1.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:child:1.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -90,12 +121,22 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:child:2.0.0",
 					Name:    "com.example:child",
 					Version: "2.0.0",
 				},
 				{
+					ID:      "org.example:example-api:2.0.0",
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:child:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api:2.0.0",
+					},
 				},
 			},
 		},
@@ -105,12 +146,22 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:test:0.0.1-SNAPSHOT",
 					Name:    "com.example:test",
 					Version: "0.0.1-SNAPSHOT",
 				},
 				{
+					ID:      "org.example:example-api:2.0.0",
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:test:0.0.1-SNAPSHOT",
+					DependsOn: []string{
+						"org.example:example-api:2.0.0",
+					},
 				},
 			},
 		},
@@ -120,16 +171,33 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:child:1.0.0",
 					Name:    "com.example:child",
 					Version: "1.0.0",
 				},
 				{
+					ID:      "org.example:example-api:4.0.0",
 					Name:    "org.example:example-api",
 					Version: "4.0.0",
 				},
 				{
+					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:child:1.0.0",
+					DependsOn: []string{
+						"org.example:example-dependency:1.2.3",
+					},
+				},
+				{
+					ID: "org.example:example-dependency:1.2.3",
+					DependsOn: []string{
+						"org.example:example-api:4.0.0",
+					},
 				},
 			},
 		},
@@ -139,13 +207,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     false,
 			want: []types.Library{
 				{
+					ID:      "com.example:child:1.0.0-SNAPSHOT",
 					Name:    "com.example:child",
 					Version: "1.0.0-SNAPSHOT",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:child:1.0.0-SNAPSHOT",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -155,13 +233,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:child:3.0.0",
 					Name:    "com.example:child",
 					Version: "3.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:child:3.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -171,17 +259,34 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:base:4.0.0",
 					Name:    "com.example:base",
 					Version: "4.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 				},
 				{
+					ID:      "org.example:example-child:2.0.0",
 					Name:    "org.example:example-child",
 					Version: "2.0.0",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:base:4.0.0",
+					DependsOn: []string{
+						"org.example:example-child:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-child:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -191,13 +296,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:child:1.0.0",
 					Name:    "com.example:child",
 					Version: "1.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:child:1.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -207,12 +322,22 @@ func TestPom_Parse(t *testing.T) {
 			local:     false,
 			want: []types.Library{
 				{
+					ID:      "com.example:child:1.0.0-SNAPSHOT",
 					Name:    "com.example:child",
 					Version: "1.0.0-SNAPSHOT",
 				},
 				{
+					ID:      "org.example:example-api:1.1.1",
 					Name:    "org.example:example-api",
 					Version: "1.1.1",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:child:1.0.0-SNAPSHOT",
+					DependsOn: []string{
+						"org.example:example-api:1.1.1",
+					},
 				},
 			},
 		},
@@ -222,76 +347,143 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "org.example:child:1.0.0",
 					Name:    "org.example:child",
 					Version: "1.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 				},
 			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "org.example:child:1.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
+				},
+			},
 		},
 		{
+			// mvn dependency:tree
+			// [INFO] com.example:soft:jar:1.0.0
+			// [INFO] +- org.example:example-api:jar:1.7.30:compile
+			// [INFO] \- org.example:example-dependency:jar:1.2.3:compile
+
 			name:      "soft requirement",
 			inputFile: filepath.Join("testdata", "soft-requirement", "pom.xml"),
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:soft:1.0.0",
 					Name:    "com.example:soft",
 					Version: "1.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 				},
 				{
+					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
 				},
 			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:soft:1.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+						"org.example:example-dependency:1.2.3",
+					},
+				},
+			},
 		},
 		{
+			// mvn dependency:tree
+			// [INFO] com.example:soft-transitive:jar:1.0.0
+			// [INFO] +- org.example:example-dependency:jar:1.2.3:compile
+			// [INFO] |  \- org.example:example-api:jar:2.0.0:compile
+			// [INFO] \- org.example:example-dependency2:jar:2.3.4:compile
 			name:      "soft requirement with transitive dependencies",
 			inputFile: filepath.Join("testdata", "soft-requirement-with-transitive-dependencies", "pom.xml"),
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:soft-transitive:1.0.0",
 					Name:    "com.example:soft-transitive",
 					Version: "1.0.0",
 				},
 				{
+					ID:      "org.example:example-api:2.0.0",
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
 				},
 				{
+					ID:      "org.example:example-dependency2:2.3.4",
+					Name:    "org.example:example-dependency2",
+					Version: "2.3.4",
+				},
+				{
+					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
 				},
+			},
+			wantDeps: []types.Dependency{
 				{
-					Name:    "org.example:example-dependency2",
-					Version: "2.3.4",
+					ID: "com.example:soft-transitive:1.0.0",
+					DependsOn: []string{
+						"org.example:example-dependency2:2.3.4",
+						"org.example:example-dependency:1.2.3",
+					},
+				},
+				{
+					ID: "org.example:example-dependency:1.2.3",
+					DependsOn: []string{
+						"org.example:example-api:2.0.0",
+					},
 				},
 			},
 		},
 		{
+			// mvn dependency:tree
+			// [INFO] com.example:hard:jar:1.0.0
+			// [INFO] +- org.example:example-api:jar:2.0.0:compile
+			// [INFO] \- org.example:example-dependency:jar:1.2.4:compile
 			name:      "hard requirement for the specified version",
 			inputFile: filepath.Join("testdata", "hard-requirement", "pom.xml"),
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:hard:1.0.0",
 					Name:    "com.example:hard",
 					Version: "1.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:2.0.0",
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
 				},
 				{
+					ID:      "org.example:example-dependency:1.2.4",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.4",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:hard:1.0.0",
+					DependsOn: []string{
+						"org.example:example-api:2.0.0",
+						"org.example:example-dependency:1.2.4",
+					},
 				},
 			},
 		},
@@ -301,6 +493,7 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:hard:1.0.0",
 					Name:    "com.example:hard",
 					Version: "1.0.0",
 					License: "Apache 2.0",
@@ -313,13 +506,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:import:2.0.0",
 					Name:    "com.example:import",
 					Version: "2.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:import:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -329,13 +532,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:import:2.0.0",
 					Name:    "com.example:import",
 					Version: "2.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:import:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -345,16 +558,33 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:exclusions:3.0.0",
 					Name:    "com.example:exclusions",
 					Version: "3.0.0",
 				},
 				{
+					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
 				},
 				{
+					ID:      "org.example:example-nested:3.3.3",
 					Name:    "org.example:example-nested",
 					Version: "3.3.3",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:exclusions:3.0.0",
+					DependsOn: []string{
+						"org.example:example-nested:3.3.3",
+					},
+				},
+				{
+					ID: "org.example:example-nested:3.3.3",
+					DependsOn: []string{
+						"org.example:example-dependency:1.2.3",
+					},
 				},
 			},
 		},
@@ -364,20 +594,34 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:wildcard-exclusions:4.0.0",
 					Name:    "com.example:wildcard-exclusions",
 					Version: "4.0.0",
 				},
 				{
-					Name:    "org.example:example-dependency",
-					Version: "1.2.3",
-				},
-				{
+					ID:      "org.example:example-dependency2:2.3.4",
 					Name:    "org.example:example-dependency2",
 					Version: "2.3.4",
 				},
 				{
+					ID:      "org.example:example-dependency:1.2.3",
+					Name:    "org.example:example-dependency",
+					Version: "1.2.3",
+				},
+				{
+					ID:      "org.example:example-nested:3.3.3",
 					Name:    "org.example:example-nested",
 					Version: "3.3.3",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:wildcard-exclusions:4.0.0",
+					DependsOn: []string{
+						"org.example:example-dependency2:2.3.4",
+						"org.example:example-dependency:1.2.3",
+						"org.example:example-nested:3.3.3",
+					},
 				},
 			},
 		},
@@ -387,16 +631,19 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:aggregation:1.0.0",
 					Name:    "com.example:aggregation",
 					Version: "1.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "com.example:module:1.1.1",
 					Name:    "com.example:module",
 					Version: "1.1.1",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 				},
@@ -408,22 +655,27 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:aggregation:1.0.0",
 					Name:    "com.example:aggregation",
 					Version: "1.0.0",
 				},
 				{
+					ID:      "com.example:module1:1.1.1",
 					Name:    "com.example:module1",
 					Version: "1.1.1",
 				},
 				{
+					ID:      "com.example:module2:1.1.1",
 					Name:    "com.example:module2",
 					Version: "1.1.1",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 				},
 				{
+					ID:      "org.example:example-api:2.0.0",
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
 				},
@@ -435,22 +687,46 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:root-pom-dep-management:1.0.0",
 					Name:    "com.example:root-pom-dep-management",
 					Version: "1.0.0",
 				},
 				{
+					ID:      "org.example:example-api:2.0.0",
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
 				},
 				// dependency version is taken from `com.example:root-pom-dep-management` from dependencyManagement
 				// not from `com.example:example-nested` from `com.example:example-nested`
 				{
+					ID:      "org.example:example-dependency:1.2.4",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.4",
 				},
 				{
+					ID:      "org.example:example-nested:3.3.3",
 					Name:    "org.example:example-nested",
 					Version: "3.3.3",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:root-pom-dep-management:1.0.0",
+					DependsOn: []string{
+						"org.example:example-nested:3.3.3",
+					},
+				},
+				{
+					ID: "org.example:example-dependency:1.2.4",
+					DependsOn: []string{
+						"org.example:example-api:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested:3.3.3",
+					DependsOn: []string{
+						"org.example:example-dependency:1.2.4",
+					},
 				},
 			},
 		},
@@ -462,20 +738,44 @@ func TestPom_Parse(t *testing.T) {
 				// Managed dependencies (org.example:example-api:1.7.30) in org.example:example-dependency-management3
 				// should not affect dependencies of example-dependency (org.example:example-api:2.0.0)
 				{
+					ID:      "org.example:example-api:2.0.0",
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
 				},
 				{
-					Name:    "org.example:example-dependency",
-					Version: "1.2.3",
-				},
-				{
+					ID:      "org.example:example-dependency-management3:1.1.1",
 					Name:    "org.example:example-dependency-management3",
 					Version: "1.1.1",
 				},
 				{
+					ID:      "org.example:example-dependency:1.2.3",
+					Name:    "org.example:example-dependency",
+					Version: "1.2.3",
+				},
+				{
+					ID:      "org.example:transitive-dependency-management:2.0.0",
 					Name:    "org.example:transitive-dependency-management",
 					Version: "2.0.0",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "org.example:example-dependency-management3:1.1.1",
+					DependsOn: []string{
+						"org.example:example-dependency:1.2.3",
+					},
+				},
+				{
+					ID: "org.example:example-dependency:1.2.3",
+					DependsOn: []string{
+						"org.example:example-api:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:transitive-dependency-management:2.0.0",
+					DependsOn: []string{
+						"org.example:example-dependency-management3:1.1.1",
+					},
 				},
 			},
 		},
@@ -485,13 +785,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:no-parent:1.0-SNAPSHOT",
 					Name:    "com.example:no-parent",
 					Version: "1.0-SNAPSHOT",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-api:1.7.30",
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:no-parent:1.0-SNAPSHOT",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+					},
 				},
 			},
 		},
@@ -501,13 +811,23 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:not-found-dependency:1.0.0",
 					Name:    "com.example:not-found-dependency",
 					Version: "1.0.0",
 					License: "Apache 2.0",
 				},
 				{
+					ID:      "org.example:example-not-found:999",
 					Name:    "org.example:example-not-found",
 					Version: "999",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:not-found-dependency:1.0.0",
+					DependsOn: []string{
+						"org.example:example-not-found:999",
+					},
 				},
 			},
 		},
@@ -517,6 +837,7 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:aggregation:1.0.0",
 					Name:    "com.example:aggregation",
 					Version: "1.0.0",
 					License: "Apache 2.0",
@@ -529,6 +850,7 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example:multiply-licenses:1.0.0",
 					Name:    "com.example:multiply-licenses",
 					Version: "1.0.0",
 					License: "MIT, Apache 2.0",
@@ -541,6 +863,7 @@ func TestPom_Parse(t *testing.T) {
 			local:     true,
 			want: []types.Library{
 				{
+					ID:      "com.example.app:submodule:1.0.0",
 					Name:    "com.example.app:submodule",
 					Version: "1.0.0",
 					License: "Apache-2.0",
@@ -567,7 +890,7 @@ func TestPom_Parse(t *testing.T) {
 
 			p := pom.NewParser(tt.inputFile, pom.WithRemoteRepos(remoteRepos), pom.WithOffline(tt.offline))
 
-			got, _, err := p.Parse(f)
+			gotLibs, gotDeps, err := p.Parse(f)
 			if tt.wantErr != "" {
 				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -575,11 +898,8 @@ func TestPom_Parse(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			sort.Slice(got, func(i, j int) bool {
-				return got[i].Name < got[j].Name
-			})
-
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, gotLibs)
+			assert.Equal(t, tt.wantDeps, gotDeps)
 		})
 	}
 }

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -26,7 +26,7 @@ func TestPom_Parse(t *testing.T) {
 	}{
 		{
 			name:      "local repository",
-			inputFile: filepath.Join("testdata", "happy", "pom.xml"),
+			inputFile: filepath.Join("testdata", "happy2", "pom.xml"),
 			local:     true,
 			want: []types.Library{
 				{
@@ -374,7 +374,6 @@ func TestPom_Parse(t *testing.T) {
 			// [INFO] com.example:soft:jar:1.0.0
 			// [INFO] +- org.example:example-api:jar:1.7.30:compile
 			// [INFO] \- org.example:example-dependency:jar:1.2.3:compile
-
 			name:      "soft requirement",
 			inputFile: filepath.Join("testdata", "soft-requirement", "pom.xml"),
 			local:     true,

--- a/pkg/java/pom/testdata/hard-requirement/pom.xml
+++ b/pkg/java/pom/testdata/hard-requirement/pom.xml
@@ -24,15 +24,11 @@
         </developer>
     </developers>
 
-    <properties>
-        <api.version>1.7.30</api.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.example</groupId>
-            <artifactId>example-api</artifactId>
-            <version>${api.version}</version>
+            <artifactId>example-nested</artifactId>
+            <version>3.3.4</version>
         </dependency>
         <dependency>
             <groupId>org.example</groupId>

--- a/pkg/java/pom/testdata/multi-module/module/pom.xml
+++ b/pkg/java/pom/testdata/multi-module/module/pom.xml
@@ -17,15 +17,11 @@
         </license>
     </licenses>
 
-    <properties>
-        <api.version>1.7.30</api.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.example</groupId>
-            <artifactId>example-api</artifactId>
-            <version>${api.version}</version>
+            <artifactId>example-dependency</artifactId>
+            <version>1.2.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/pkg/java/pom/testdata/repository/org/example/example-nested/3.3.4/example-nested-3.3.4.pom
+++ b/pkg/java/pom/testdata/repository/org/example/example-nested/3.3.4/example-nested-3.3.4.pom
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-nested</artifactId>
+    <version>3.3.4</version>
+
+    <packaging>jar</packaging>
+    <name>Example API Dependency</name>
+    <description>The example API</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>[1.2.3]</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/java/pom/utils.go
+++ b/pkg/java/pom/utils.go
@@ -21,6 +21,6 @@ func isProperty(version string) bool {
 	return false
 }
 
-func PackageID(name, version string) string {
+func packageID(name, version string) string {
 	return fmt.Sprintf("%s:%s", name, version)
 }

--- a/pkg/java/pom/utils.go
+++ b/pkg/java/pom/utils.go
@@ -1,6 +1,7 @@
 package pom
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -18,4 +19,8 @@ func isProperty(version string) bool {
 		return true
 	}
 	return false
+}
+
+func PackageID(name, version string) string {
+	return fmt.Sprintf("%s:%s", name, version)
 }


### PR DESCRIPTION
## Description
Add `ID` and `dependsOn` support.
Fill `Indirect` field.

Some nuances:
- root/module artifact is marked as `Direct`.
- dependencies of root/module artifact are marked as `Direct` (this is necessary to be able to exclude indirect dependencies from Trivy report - https://github.com/aquasecurity/trivy/discussions/4870).
- root artifact doesn't contains modules in `dependsOn` (see more [here](https://github.com/DmitriyLewen/go-dep-parser/blob/bb82a5149a74ed72accd9a8a171cb08e4378f15e/pkg/java/pom/parse_test.go#L661-L691))

## Related Issue
- Close #126
- aquasecurity/trivy/issues/3272