### PR TITLE
fix(npm): add init of root deps

### DIFF
--- a/pkg/nodejs/npm/parse.go
+++ b/pkg/nodejs/npm/parse.go
@@ -178,6 +178,13 @@ func resolveLinks(packages map[string]Package) {
 		return
 	}
 
+	// Init root Dependencies map
+	if packages[""].Dependencies == nil {
+		rootPackage := packages[""]
+		rootPackage.Dependencies = make(map[string]string)
+		packages[""] = rootPackage
+	}
+
 	workspaces := packages[""].Workspaces
 	for pkgPath, pkg := range packages {
 		for linkPath, link := range links {

--- a/pkg/nodejs/npm/parse.go
+++ b/pkg/nodejs/npm/parse.go
@@ -178,14 +178,12 @@ func resolveLinks(packages map[string]Package) {
 		return
 	}
 
-	// Init root Dependencies map
-	if packages[""].Dependencies == nil {
-		rootPackage := packages[""]
-		rootPackage.Dependencies = make(map[string]string)
-		packages[""] = rootPackage
+	rootPkg := packages[""]
+	if rootPkg.Dependencies == nil {
+		rootPkg.Dependencies = make(map[string]string)
 	}
 
-	workspaces := packages[""].Workspaces
+	workspaces := rootPkg.Workspaces
 	for pkgPath, pkg := range packages {
 		for linkPath, link := range links {
 			if !strings.HasPrefix(pkgPath, link.Resolved) {
@@ -204,11 +202,12 @@ func resolveLinks(packages map[string]Package) {
 			delete(packages, pkgPath)
 
 			if isWorkspace(pkgPath, workspaces) {
-				packages[""].Dependencies[pkgNameFromPath(linkPath)] = pkg.Version
+				rootPkg.Dependencies[pkgNameFromPath(linkPath)] = pkg.Version
 			}
 			break
 		}
 	}
+	packages[""] = rootPkg
 }
 
 func isWorkspace(pkgPath string, workspaces []string) bool {

--- a/pkg/nodejs/npm/parse_test.go
+++ b/pkg/nodejs/npm/parse_test.go
@@ -41,6 +41,12 @@ func TestParse(t *testing.T) {
 			want:     npmV3WithWorkspaceLibs,
 			wantDeps: npmV3WithWorkspaceDeps,
 		},
+		{
+			name:     "lock version v3 with workspace and without direct deps field",
+			file:     "testdata/package-lock_v3_without_root_deps_field.json",
+			want:     npmV3WithoutRootDepsField,
+			wantDeps: npmV3WithoutRootDepsFieldDeps,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/nodejs/npm/parse_testcase.go
+++ b/pkg/nodejs/npm/parse_testcase.go
@@ -131,4 +131,21 @@ var (
 		{ID: "function1@", DependsOn: []string{"nested_func@1.0.0"}},
 		{ID: "nested_func@1.0.0", DependsOn: []string{"debug@2.6.9"}},
 	}
+
+	// docker run --name node --rm -it node@sha256:51dd437f31812df71108b81385e2945071ec813d5815fa3403855669c8f3432b sh
+	// mkdir node_v3_without_direct_deps && cd node_v3_without_direct_deps
+	// npm init --force
+	// npm init -w ./functions/func1 --force
+	// npm install --save debug@2.6.9 -w func1
+	// libraries are filled manually
+	npmV3WithoutRootDepsField = []types.Library{
+		{ID: "debug@2.6.9", Name: "debug", Version: "2.6.9", Indirect: true, ExternalReferences: []types.ExternalRef{{Type: types.RefOther, URL: "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"}}, Locations: []types.Location{{StartLine: 22, EndLine: 29}}},
+		{ID: "func1@1.0.0", Name: "func1", Version: "1.0.0", Indirect: false, ExternalReferences: []types.ExternalRef{{Type: types.RefOther, URL: "functions/func1"}}, Locations: []types.Location{{StartLine: 15, EndLine: 21}}},
+		{ID: "ms@2.0.0", Name: "ms", Version: "2.0.0", Indirect: true, ExternalReferences: []types.ExternalRef{{Type: types.RefOther, URL: "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"}}, Locations: []types.Location{{StartLine: 34, EndLine: 38}}},
+	}
+
+	npmV3WithoutRootDepsFieldDeps = []types.Dependency{
+		{ID: "debug@2.6.9", DependsOn: []string{"ms@2.0.0"}},
+		{ID: "func1@1.0.0", DependsOn: []string{"debug@2.6.9"}},
+	}
 )

--- a/pkg/nodejs/npm/testdata/package-lock_v3_without_root_deps_field.json
+++ b/pkg/nodejs/npm/testdata/package-lock_v3_without_root_deps_field.json
@@ -1,0 +1,40 @@
+{
+  "name": "node_v3_without_direct_deps",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node_v3_without_direct_deps",
+      "version": "1.0.0",
+      "license": "ISC",
+      "workspaces": [
+        "functions/func1"
+      ]
+    },
+    "functions/func1": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^2.6.9"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/func1": {
+      "resolved": "functions/func1",
+      "link": true
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    }
+  }
+}


### PR DESCRIPTION
## Description
There is case when root `Dependencies` field (packages[""].Dependencies) is `nil`.
We need initialize this map to insert direct dependencies from links.

## Related Issues
- https://github.com/aquasecurity/trivy/issues/4923