### PR TITLE
refactor(cocoapods): use `utils.PackageID` for ID

### DIFF
--- a/pkg/swift/cocoapods/parse_test.go
+++ b/pkg/swift/cocoapods/parse_test.go
@@ -2,8 +2,6 @@ package cocoapods_test
 
 import (
 	"os"
-	"sort"
-	"strings"
 	"testing"
 
 	"github.com/aquasecurity/go-dep-parser/pkg/swift/cocoapods"
@@ -24,49 +22,49 @@ func TestParse(t *testing.T) {
 			inputFile: "testdata/happy.lock",
 			wantLibs: []types.Library{
 				{
-					ID:      "AppCenter/4.2.0",
-					Name:    "AppCenter",
-					Version: "4.2.0",
-				},
-				{
-					ID:      "AppCenter/Analytics/4.2.0",
+					ID:      "AppCenter/Analytics@4.2.0",
 					Name:    "AppCenter/Analytics",
 					Version: "4.2.0",
 				},
 				{
-					ID:      "AppCenter/Core/4.2.0",
+					ID:      "AppCenter/Core@4.2.0",
 					Name:    "AppCenter/Core",
 					Version: "4.2.0",
 				},
 				{
-					ID:      "AppCenter/Crashes/4.2.0",
+					ID:      "AppCenter/Crashes@4.2.0",
 					Name:    "AppCenter/Crashes",
 					Version: "4.2.0",
 				},
 				{
-					ID:      "KeychainAccess/4.2.1",
+					ID:      "AppCenter@4.2.0",
+					Name:    "AppCenter",
+					Version: "4.2.0",
+				},
+				{
+					ID:      "KeychainAccess@4.2.1",
 					Name:    "KeychainAccess",
 					Version: "4.2.1",
 				},
 			},
 			wantDeps: []types.Dependency{
 				{
-					ID: "AppCenter/4.2.0",
+					ID: "AppCenter/Analytics@4.2.0",
 					DependsOn: []string{
-						"AppCenter/Analytics/4.2.0",
-						"AppCenter/Crashes/4.2.0",
+						"AppCenter/Core@4.2.0",
 					},
 				},
 				{
-					ID: "AppCenter/Analytics/4.2.0",
+					ID: "AppCenter/Crashes@4.2.0",
 					DependsOn: []string{
-						"AppCenter/Core/4.2.0",
+						"AppCenter/Core@4.2.0",
 					},
 				},
 				{
-					ID: "AppCenter/Crashes/4.2.0",
+					ID: "AppCenter@4.2.0",
 					DependsOn: []string{
-						"AppCenter/Core/4.2.0",
+						"AppCenter/Analytics@4.2.0",
+						"AppCenter/Crashes@4.2.0",
 					},
 				},
 			},
@@ -89,18 +87,6 @@ func TestParse(t *testing.T) {
 
 			gotLibs, gotDeps, err := cocoapods.NewParser().Parse(f)
 			require.NoError(t, err)
-
-			sort.Slice(gotLibs, func(i, j int) bool {
-				ret := strings.Compare(gotLibs[i].Name, gotLibs[j].Name)
-				if ret != 0 {
-					return ret < 0
-				}
-				return gotLibs[i].Version < gotLibs[j].Version
-			})
-
-			sort.Slice(gotDeps, func(i, j int) bool {
-				return gotDeps[i].ID < gotDeps[j].ID
-			})
 
 			assert.Equal(t, tt.wantLibs, gotLibs)
 			assert.Equal(t, tt.wantDeps, gotDeps)


### PR DESCRIPTION
## Description
`Purl` uses `@` to separate package name and version - https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#cocoapods
Use same logic.