### PR TITLE
fix(python): add `non-separable` prefix for python packaging

### DIFF
--- a/pkg/python/packaging/parse_test.go
+++ b/pkg/python/packaging/parse_test.go
@@ -33,7 +33,7 @@ func TestParse(t *testing.T) {
 			// cd /usr/lib/python3.9/site-packages/setuptools-52.0.0-py3.9.egg-info/
 			// cat PKG-INFO | grep -e "^Name:" -e "^Version:" -e "^License:" | cut -d" " -f2- | \
 			// tr "\n" "\t" | awk -F "\t" '{printf("\{\""$1"\", \""$2"\", \""$3"\"\}\n")}'
-			want: []types.Library{{Name: "setuptools", Version: "51.3.3", License: "UNKNOWN"}},
+			want: []types.Library{{Name: "setuptools", Version: "51.3.3", License: "non-separable: UNKNOWN"}},
 		},
 		{
 			name:  "egg-info",
@@ -44,7 +44,7 @@ func TestParse(t *testing.T) {
 			// cd /usr/lib/python3.9/site-packages/
 			// cat distlib-0.3.1-py3.9.egg-info | grep -e "^Name:" -e "^Version:" -e "^License:" | cut -d" " -f2- | \
 			// tr "\n" "\t" | awk -F "\t" '{printf("\{\""$1"\", \""$2"\", \""$3"\"\}\n")}'
-			want: []types.Library{{Name: "distlib", Version: "0.3.1", License: "Python license"}},
+			want: []types.Library{{Name: "distlib", Version: "0.3.1", License: "non-separable: Python license"}},
 		},
 		{
 			name:  "wheel METADATA",
@@ -60,12 +60,12 @@ func TestParse(t *testing.T) {
 			want: []types.Library{{Name: "simple", Version: "0.1.0", License: ""}},
 		},
 		{
-			name: "wheel METADATA",
+			name: "wheel METADATA with license",
 
 			// for single METADATA file with known name
 			// cat "{{ libname }}.METADATA | grep -e "^Name:" -e "^Version:" -e "^License:" | cut -d" " -f2- | tr "\n" "\t" | awk -F "\t" '{printf("\{\""$1"\", \""$2"\", \""$3"\"\}\n")}'
 			input: "testdata/distlib-0.3.1.METADATA",
-			want:  []types.Library{{Name: "distlib", Version: "0.3.1", License: "Python license"}},
+			want:  []types.Library{{Name: "distlib", Version: "0.3.1", License: "non-separable: Python license"}},
 		},
 		{
 			name:    "invalid",
@@ -90,7 +90,7 @@ func TestParse(t *testing.T) {
 				{
 					Name:    "zipp",
 					Version: "3.12.1",
-					License: "MIT License",
+					License: "Apache Software License, MIT License",
 				},
 			},
 		},
@@ -101,7 +101,7 @@ func TestParse(t *testing.T) {
 				{
 					Name:    "networkx",
 					Version: "3.0",
-					License: "file://LICENSE.txt",
+					License: "file://LICENSE-APACHE, file://LICENSE.txt",
 				},
 			},
 		},

--- a/pkg/python/packaging/testdata/networkx-3.0.METADATA
+++ b/pkg/python/packaging/testdata/networkx-3.0.METADATA
@@ -31,6 +31,7 @@ Classifier: Topic :: Scientific/Engineering :: Information Analysis
 Classifier: Topic :: Scientific/Engineering :: Mathematics
 Classifier: Topic :: Scientific/Engineering :: Physics
 Requires-Python: >=3.8
+License-File: LICENSE-APACHE
 License-File: LICENSE.txt
 Provides-Extra: default
 Requires-Dist: numpy (>=1.20) ; extra == 'default'

--- a/pkg/python/packaging/testdata/zipp-3.12.1.METADATA
+++ b/pkg/python/packaging/testdata/zipp-3.12.1.METADATA
@@ -7,6 +7,7 @@ Author: Jason R. Coombs
 Author-email: jaraco@jaraco.com
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Intended Audience :: Developers
+Classifier: License :: OSI Approved :: Apache Software License
 Classifier: License :: OSI Approved :: MIT License
 Classifier: Programming Language :: Python :: 3
 Classifier: Programming Language :: Python :: 3 :: Only

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -74,4 +74,6 @@ const (
 	RefVCS          RefType = "vcs"
 	RefIssueTracker RefType = "issue-tracker"
 	RefOther        RefType = "other"
+
+	NonSeparableLicensePrefix = "non-separable: "
 )


### PR DESCRIPTION
## Description
- `License` field can contain information about various licenses, license exceptions , etc. - https://packaging.python.org/en/latest/specifications/core-metadata/#license.
We need to mark these licenses so we don't have to split them in Trivy, because it is not possible.

- License Classifiers and License File fields are intended for multiple use. Add support for these cases.
