### PR TITLE
fix(pom): compare ArtifactIDs for base and parent pom's when `relativePath` field is used

### DIFF
--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -510,6 +510,13 @@ func (p *parser) tryRelativePath(parentArtifact artifact, currentPath, relativeP
 		return nil, err
 	}
 
+	// We can inherit GroupID from parent (requires p.analyze function to get GroupID)
+	// Version can contain a property (requires p.analyze function to get version)
+	// But ArtifactID must be the same for parent and base poms
+	// This check is necessary to avoid an infinite loop when using relatedPath or `../pom.xml`
+	if pom.artifact().ArtifactID != parentArtifact.ArtifactID {
+		return nil, xerrors.New("'parent.relativePath' points at wrong local POM")
+	}
 	result, err := p.analyze(pom, analysisOptions{})
 	if err != nil {
 		return nil, xerrors.Errorf("analyze error: %w", err)

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -510,10 +510,12 @@ func (p *parser) tryRelativePath(parentArtifact artifact, currentPath, relativeP
 		return nil, err
 	}
 
-	// We can inherit GroupID from parent (requires p.analyze function to get GroupID)
-	// Version can contain a property (requires p.analyze function to get version)
-	// But ArtifactID must be the same for parent and base poms
-	// This check is necessary to avoid an infinite loop when using relatedPath or `../pom.xml`
+	// To avoid an infinite loop or parsing the wrong parent when using relatedPath or `../pom.xml`,
+	// we need to compare GAV of `parentArtifact` (`parent` tag from base pom) and GAV of pom from `relativePath`.
+	// See `compare ArtifactIDs for base and parent pom's` test for example.
+	// But GroupID can be inherited from parent (`p.analyze` function is required to get the GroupID).
+	// Version can contain a property (`p.analyze` function is required to get the GroupID).
+	// So we can only match ArtifactID's.
 	if pom.artifact().ArtifactID != parentArtifact.ArtifactID {
 		return nil, xerrors.New("'parent.relativePath' points at wrong local POM")
 	}

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -984,6 +984,19 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "compare ArtifactIDs for base and parent pom's",
+			inputFile: filepath.Join("testdata", "no-parent-infinity-loop", "pom.xml"),
+			local:     true,
+			want: []types.Library{
+				{
+					ID:      "com.example:child:1.0.0",
+					Name:    "com.example:child",
+					Version: "1.0.0",
+					License: "The Apache Software License, Version 2.0",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/java/pom/testdata/no-parent-infinity-loop/parent/pom.xml
+++ b/pkg/java/pom/testdata/no-parent-infinity-loop/parent/pom.xml
@@ -2,14 +2,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.example</groupId>
-        <artifactId>top-parent</artifactId>
-        <version>1.0.0</version>
-        <relativePath>../top-parent</relativePath>
-    </parent>
-
-
     <groupId>com.example</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.0</version>
@@ -17,5 +9,11 @@
     <packaging>pom</packaging>
     <name>parent</name>
     <description>Parent</description>
+
+    <parent>
+        <groupId>org.example</groupId>
+        <artifactId>example-api</artifactId>
+        <version>1.7.30</version>
+    </parent>
 
 </project>

--- a/pkg/java/pom/testdata/no-parent-infinity-loop/pom.xml
+++ b/pkg/java/pom/testdata/no-parent-infinity-loop/pom.xml
@@ -2,20 +2,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <artifactId>child</artifactId>
+
+    <name>child</name>
+    <description>Child</description>
+
     <parent>
         <groupId>com.example</groupId>
-        <artifactId>top-parent</artifactId>
+        <artifactId>parent</artifactId>
         <version>1.0.0</version>
-        <relativePath>../top-parent</relativePath>
+        <relativePath>./parent</relativePath>
     </parent>
-
-
-    <groupId>com.example</groupId>
-    <artifactId>parent</artifactId>
-    <version>1.0.0</version>
-
-    <packaging>pom</packaging>
-    <name>parent</name>
-    <description>Parent</description>
 
 </project>


### PR DESCRIPTION
## Description
We need to compare `ArtifactID`s for base and parent pom's when `relativePath == ../pom.xml` is used.
it is needed to avoid cases when we get incorrect parent or get infinity loop (if `../pom.xml` is scanned pom.xml).

We can inherit `GroupID`. Also `Version` can contains property.
So we need to compare only `ArtifactID`.

New test contains simple example - https://github.com/DmitriyLewen/go-dep-parser/blob/7d2c865da8912f9f3ea475cc94da61c819dcae0d/pkg/java/pom/parse_test.go#L987-L999
Example from real life - aquasecurity/trivy/discussions/5445

## Related Issues
- aquasecurity/trivy/issues/5453