### PR TITLE
feat(jar): add version for SearchByArtifactID function

### DIFF
--- a/pkg/java/jar/parse.go
+++ b/pkg/java/jar/parse.go
@@ -27,7 +27,7 @@ var (
 type Client interface {
 	Exists(groupID, artifactID string) (bool, error)
 	SearchBySHA1(sha1 string) (Properties, error)
-	SearchByArtifactID(artifactID string) (string, error)
+	SearchByArtifactID(artifactID, version string) (string, error)
 }
 
 type Parser struct {
@@ -164,7 +164,7 @@ func (p *Parser) parseArtifact(filePath string, size int64, r dio.ReadSeekerAt) 
 
 	// Try to search groupId by artifactId via sonatype API
 	// When some artifacts have the same groupIds, it might result in false detection.
-	fileProps.GroupID, err = p.client.SearchByArtifactID(fileProps.ArtifactID)
+	fileProps.GroupID, err = p.client.SearchByArtifactID(fileProps.ArtifactID, fileProps.Version)
 	if err == nil {
 		log.Logger.Debugw("POM was determined in a heuristic way", zap.String("file", fileName),
 			zap.String("artifact", fileProps.String()))

--- a/pkg/java/jar/sonatype/sonatype.go
+++ b/pkg/java/jar/sonatype/sonatype.go
@@ -153,7 +153,7 @@ func (s Sonatype) SearchBySHA1(sha1 string) (jar.Properties, error) {
 	}, nil
 }
 
-func (s Sonatype) SearchByArtifactID(artifactID string) (string, error) {
+func (s Sonatype) SearchByArtifactID(artifactID, _ string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, s.baseURL, nil)
 	if err != nil {
 		return "", xerrors.Errorf("unable to initialize HTTP client: %w", err)


### PR DESCRIPTION
## Description
Add version to `SearchByArtifactID` function (for [Client](https://github.com/aquasecurity/go-dep-parser/blob/fc7f2b470d8926796902748479355ac92e153aaa/pkg/java/jar/parse.go#L27-L31) interface) so that you can get the GroupId with only the required version.
See aquasecurity/trivy/issues/5627