### PR TITLE
fix: check Dev field for UniqueLibraries func

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -30,11 +30,21 @@ func UniqueLibraries(libs []types.Library) []types.Library {
 		identifier := fmt.Sprintf("%s@%s", lib.Name, lib.Version)
 		if l, ok := unique[identifier]; !ok {
 			unique[identifier] = lib
-		} else if len(lib.Locations) > 0 {
-			// merge locations
-			l.Locations = append(l.Locations, lib.Locations...)
-			sort.Sort(l.Locations)
-			unique[identifier] = l
+		} else {
+			// There are times when we get 2 same libraries as root and dev dependencies.
+			// https://github.com/aquasecurity/trivy/issues/5532
+			// In these cases, we need to mark the dependency as a root dependency.
+			if !lib.Dev {
+				l.Dev = lib.Dev
+				unique[identifier] = l
+			}
+
+			if len(lib.Locations) > 0 {
+				// merge locations
+				l.Locations = append(l.Locations, lib.Locations...)
+				sort.Sort(l.Locations)
+				unique[identifier] = l
+			}
 		}
 	}
 	libSlice := maps.Values(unique)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,117 @@
+package utils
+
+import (
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestUniqueLibraries(t *testing.T) {
+	tests := []struct {
+		name     string
+		libs     []types.Library
+		wantLibs []types.Library
+	}{
+		{
+			name: "happy path merge locations",
+			libs: []types.Library{
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Locations: []types.Location{
+						{
+							StartLine: 10,
+							EndLine:   14,
+						},
+					},
+				},
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Locations: []types.Location{
+						{
+							StartLine: 24,
+							EndLine:   30,
+						},
+					},
+				},
+			},
+			wantLibs: []types.Library{
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Locations: []types.Location{
+						{
+							StartLine: 10,
+							EndLine:   14,
+						},
+						{
+							StartLine: 24,
+							EndLine:   30,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "happy path Dev and Root deps",
+			libs: []types.Library{
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Dev:     true,
+				},
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Dev:     false,
+				},
+			},
+			wantLibs: []types.Library{
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Dev:     false,
+				},
+			},
+		},
+		{
+			name: "happy path Root and Dev deps",
+			libs: []types.Library{
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Dev:     false,
+				},
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Dev:     true,
+				},
+			},
+			wantLibs: []types.Library{
+				{
+					ID:      "asn1@0.2.6",
+					Name:    "asn1",
+					Version: "0.2.6",
+					Dev:     false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLibs := UniqueLibraries(tt.libs)
+			require.Equal(t, tt.wantLibs, gotLibs)
+		})
+	}
+}


### PR DESCRIPTION
## Description
We need to check (and not overwrite) `Dev` field when retrieving uniq libs (`utils.UniqueLibraries` function).
See aquasecurity/trivy/issues/5532 for more details.