### PR TITLE
fix(pom): don't remove excluded deps from upper pom's

### DIFF
--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -642,6 +642,51 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "exclusions in child",
+			inputFile: filepath.Join("testdata", "exclusions-in-child", "pom.xml"),
+			local:     true,
+			want: []types.Library{
+				{
+					ID:      "com.example:example:1.0.0",
+					Name:    "com.example:example",
+					Version: "1.0.0",
+				},
+				{
+					ID:       "org.example:example-api:1.7.30",
+					Name:     "org.example:example-api",
+					Version:  "1.7.30",
+					Indirect: true,
+					License:  "The Apache Software License, Version 2.0",
+				},
+				{
+					ID:       "org.example:example-dependency:1.2.3",
+					Name:     "org.example:example-dependency",
+					Version:  "1.2.3",
+					Indirect: true,
+				},
+				{
+					ID:      "org.example:example-exclusions:4.0.0",
+					Name:    "org.example:example-exclusions",
+					Version: "4.0.0",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "com.example:example:1.0.0",
+					DependsOn: []string{
+						"org.example:example-exclusions:4.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-exclusions:4.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.7.30",
+						"org.example:example-dependency:1.2.3",
+					},
+				},
+			},
+		},
+		{
 			name:      "exclusions with wildcards",
 			inputFile: filepath.Join("testdata", "wildcard-exclusions", "pom.xml"),
 			local:     true,

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"maps"
 	"reflect"
 	"strings"
 
@@ -253,10 +254,12 @@ func (d pomDependency) Resolve(props map[string]string, depManagement, rootDepMa
 
 // ToArtifact converts dependency to artifact.
 // It should be called after calling Resolve() so that variables can be evaluated.
-func (d pomDependency) ToArtifact(exclusions map[string]struct{}) artifact {
-	if exclusions == nil {
-		exclusions = map[string]struct{}{}
-	}
+func (d pomDependency) ToArtifact(ex map[string]struct{}) artifact {
+	// To avoid shadow adding exclusions to top pom's,
+	// we need to initialize a new map for each new artifact
+	// See `exclusions in child` test for more information
+	exclusions := map[string]struct{}{}
+	maps.Copy(exclusions, ex)
 	for _, e := range d.Exclusions.Exclusion {
 		exclusions[fmt.Sprintf("%s:%s", e.GroupID, e.ArtifactID)] = struct{}{}
 	}

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -259,7 +259,9 @@ func (d pomDependency) ToArtifact(ex map[string]struct{}) artifact {
 	// we need to initialize a new map for each new artifact
 	// See `exclusions in child` test for more information
 	exclusions := map[string]struct{}{}
-	maps.Copy(exclusions, ex)
+	if ex != nil {
+		exclusions = maps.Clone(ex)
+	}
 	for _, e := range d.Exclusions.Exclusion {
 		exclusions[fmt.Sprintf("%s:%s", e.GroupID, e.ArtifactID)] = struct{}{}
 	}

--- a/pkg/java/pom/testdata/exclusions-in-child/pom.xml
+++ b/pkg/java/pom/testdata/exclusions-in-child/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-exclusions</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/java/pom/testdata/repository/org/example/example-exclusions/4.0.0/example-exclusions-4.0.0.pom
+++ b/pkg/java/pom/testdata/repository/org/example/example-exclusions/4.0.0/example-exclusions-4.0.0.pom
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-exclusions</artifactId>
+    <version>4.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>1.2.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.example</groupId>
+                    <artifactId>example-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
## Description
Fixed cases where we were removing excluded deps from upper pom's.
Example - https://github.com/aquasecurity/trivy/issues/5827
Test to better understand the fix - https://github.com/aquasecurity/go-dep-parser/blob/bf1b2d1cb5f5ad139c03d378674969ecd410d335/pkg/java/pom/parse_test.go#L689-L725