### PR TITLE
feat(pom): add support of line numbers for deps from base pom.xml

### DIFF
--- a/pkg/java/pom/artifact.go
+++ b/pkg/java/pom/artifact.go
@@ -29,7 +29,7 @@ type artifact struct {
 	Root   bool
 	Direct bool
 
-	Location types.Locations
+	Locations types.Locations
 }
 
 func newArtifact(groupID, artifactID, version string, licenses []string, props map[string]string) artifact {
@@ -54,9 +54,11 @@ func (a artifact) JoinLicenses() string {
 }
 
 func (a artifact) ToPOMLicenses() pomLicenses {
-	return pomLicenses{License: lo.Map(a.Licenses, func(lic string, _ int) pomLicense {
-		return pomLicense{Name: lic}
-	})}
+	return pomLicenses{
+		License: lo.Map(a.Licenses, func(lic string, _ int) pomLicense {
+			return pomLicense{Name: lic}
+		}),
+	}
 }
 
 func (a artifact) Inherit(parent artifact) artifact {

--- a/pkg/java/pom/artifact.go
+++ b/pkg/java/pom/artifact.go
@@ -2,6 +2,7 @@ package pom
 
 import (
 	"fmt"
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
 	"os"
 	"regexp"
 	"strings"
@@ -27,8 +28,7 @@ type artifact struct {
 	Root   bool
 	Direct bool
 
-	StartLine int
-	EndLine   int
+	Location types.Locations
 }
 
 func newArtifact(groupID, artifactID, version string, licenses []string, props map[string]string) artifact {

--- a/pkg/java/pom/artifact.go
+++ b/pkg/java/pom/artifact.go
@@ -2,14 +2,15 @@ package pom
 
 import (
 	"fmt"
-	"github.com/aquasecurity/go-dep-parser/pkg/types"
 	"os"
 	"regexp"
 	"strings"
 
-	"github.com/aquasecurity/go-dep-parser/pkg/log"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
+
+	"github.com/aquasecurity/go-dep-parser/pkg/log"
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
 )
 
 var (

--- a/pkg/java/pom/artifact.go
+++ b/pkg/java/pom/artifact.go
@@ -26,6 +26,9 @@ type artifact struct {
 	Module bool
 	Root   bool
 	Direct bool
+
+	StartLine int
+	EndLine   int
 }
 
 func newArtifact(groupID, artifactID, version string, licenses []string, props map[string]string) artifact {

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -382,10 +382,7 @@ func (p *parser) parseDependencies(deps []pomDependency, props map[string]string
 			continue
 		}
 
-		art := d.ToArtifact(opts.exclusions)
-		if !opts.lineNumber {
-			art.Locations = nil
-		}
+		art := d.ToArtifact(opts)
 
 		dependencies = append(dependencies, art)
 	}

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -382,9 +382,7 @@ func (p *parser) parseDependencies(deps []pomDependency, props map[string]string
 			continue
 		}
 
-		art := d.ToArtifact(opts)
-
-		dependencies = append(dependencies, art)
+		dependencies = append(dependencies, d.ToArtifact(opts))
 	}
 	return dependencies
 }

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -156,9 +156,8 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 				art.Direct = true
 			}
 			// We don't need to overwrite dependency location for hard links
-			if uniqueArt.EndLine != 0 {
-				art.StartLine = uniqueArt.StartLine
-				art.EndLine = uniqueArt.EndLine
+			if uniqueArt.Location != nil {
+				art.Location = uniqueArt.Location
 			}
 		}
 
@@ -197,12 +196,11 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 		if !art.IsEmpty() {
 			// Override the version
 			uniqArtifacts[art.Name()] = artifact{
-				Version:   art.Version,
-				Licenses:  result.artifact.Licenses,
-				Direct:    art.Direct,
-				Root:      art.Root,
-				StartLine: art.StartLine,
-				EndLine:   art.EndLine,
+				Version:  art.Version,
+				Licenses: result.artifact.Licenses,
+				Direct:   art.Direct,
+				Root:     art.Root,
+				Location: art.Location,
 			}
 
 			// save only dependency names
@@ -224,13 +222,8 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 			Indirect: !art.Direct,
 		}
 		// We need to add location only for deps from `Dependencies` tag of base pom.xml file
-		if art.Direct && !art.Root && art.EndLine != 0 {
-			lib.Locations = types.Locations{
-				{
-					StartLine: art.StartLine,
-					EndLine:   art.EndLine,
-				},
-			}
+		if art.Direct && !art.Root && art.Location != nil {
+			lib.Locations = art.Location
 		}
 		libs = append(libs, lib)
 
@@ -492,8 +485,7 @@ func (p *parser) parseParent(currentPath string, parent pomParent) (analysisResu
 
 	// We don't need to store the location of parent dependencies to avoid confusion.
 	result.dependencies = lo.Map(result.dependencies, func(a artifact, _ int) artifact {
-		a.StartLine = 0
-		a.EndLine = 0
+		a.Location = nil
 		return a
 	})
 

--- a/pkg/java/pom/parse.go
+++ b/pkg/java/pom/parse.go
@@ -642,3 +642,22 @@ func parsePom(r io.Reader) (*pomXML, error) {
 	}
 	return parsed, nil
 }
+
+func (deps *pomDependencies) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	*deps = pomDependencies{}
+	for {
+		var dep pomDependency
+		err := d.Decode(&dep)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		endLine, _ := d.InputPos()
+		dep.endLine = endLine
+
+		(*deps).Dependency = append((*deps).Dependency, dep)
+	}
+	return nil
+}

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -42,7 +42,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "The Apache Software License, Version 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 33,
+							StartLine: 32,
 							EndLine:   36,
 						},
 					},
@@ -75,7 +75,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "The Apache Software License, Version 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 33,
+							StartLine: 32,
 							EndLine:   36,
 						},
 					},
@@ -102,7 +102,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "2.3.4",
 					Locations: types.Locations{
 						{
-							StartLine: 18,
+							StartLine: 17,
 							EndLine:   21,
 						},
 					},
@@ -127,7 +127,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "The Apache Software License, Version 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 34,
+							StartLine: 33,
 							EndLine:   37,
 						},
 					},
@@ -159,7 +159,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "The Apache Software License, Version 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 19,
+							StartLine: 18,
 							EndLine:   22,
 						},
 					},
@@ -228,7 +228,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "1.2.3",
 					Locations: types.Locations{
 						{
-							StartLine: 23,
+							StartLine: 22,
 							EndLine:   26,
 						},
 					},
@@ -334,7 +334,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "Apache 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 29,
+							StartLine: 28,
 							EndLine:   32,
 						},
 					},
@@ -373,7 +373,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "The Apache Software License, Version 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 27,
+							StartLine: 26,
 							EndLine:   30,
 						},
 					},
@@ -437,7 +437,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "The Apache Software License, Version 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 26,
+							StartLine: 25,
 							EndLine:   29,
 						},
 					},
@@ -475,7 +475,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "The Apache Software License, Version 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 33,
+							StartLine: 32,
 							EndLine:   36,
 						},
 					},
@@ -548,7 +548,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "1.2.3",
 					Locations: types.Locations{
 						{
-							StartLine: 14,
+							StartLine: 13,
 							EndLine:   17,
 						},
 					},
@@ -617,7 +617,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "3.3.4",
 					Locations: types.Locations{
 						{
-							StartLine: 29,
+							StartLine: 28,
 							EndLine:   32,
 						},
 					},
@@ -746,7 +746,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "3.3.3",
 					Locations: types.Locations{
 						{
-							StartLine: 25,
+							StartLine: 14,
 							EndLine:   28,
 						},
 					},
@@ -796,7 +796,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "4.0.0",
 					Locations: types.Locations{
 						{
-							StartLine: 11,
+							StartLine: 10,
 							EndLine:   14,
 						},
 					},
@@ -845,7 +845,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "1.2.3",
 					Locations: types.Locations{
 						{
-							StartLine: 21,
+							StartLine: 14,
 							EndLine:   24,
 						},
 					},
@@ -1014,7 +1014,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "3.3.3",
 					Locations: types.Locations{
 						{
-							StartLine: 21,
+							StartLine: 20,
 							EndLine:   24,
 						},
 					},
@@ -1061,7 +1061,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "1.1.1",
 					Locations: types.Locations{
 						{
-							StartLine: 15,
+							StartLine: 14,
 							EndLine:   18,
 						},
 					},
@@ -1117,7 +1117,7 @@ func TestPom_Parse(t *testing.T) {
 					License: "The Apache Software License, Version 2.0",
 					Locations: types.Locations{
 						{
-							StartLine: 28,
+							StartLine: 27,
 							EndLine:   31,
 						},
 					},
@@ -1149,7 +1149,7 @@ func TestPom_Parse(t *testing.T) {
 					Version: "999",
 					Locations: types.Locations{
 						{
-							StartLine: 22,
+							StartLine: 21,
 							EndLine:   25,
 						},
 					},

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -794,6 +794,12 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-exclusions:4.0.0",
 					Name:    "org.example:example-exclusions",
 					Version: "4.0.0",
+					Locations: types.Locations{
+						{
+							StartLine: 11,
+							EndLine:   14,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{

--- a/pkg/java/pom/parse_test.go
+++ b/pkg/java/pom/parse_test.go
@@ -40,6 +40,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 33,
+							EndLine:   36,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -67,6 +73,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 33,
+							EndLine:   36,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -88,6 +100,12 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-offline:2.3.4",
 					Name:    "org.example:example-offline",
 					Version: "2.3.4",
+					Locations: types.Locations{
+						{
+							StartLine: 18,
+							EndLine:   21,
+						},
+					},
 				},
 			},
 		},
@@ -107,6 +125,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 34,
+							EndLine:   37,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -133,6 +157,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 19,
+							EndLine:   22,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -159,6 +189,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "2.0.0",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 18,
+							EndLine:   21,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -190,6 +226,12 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
+					Locations: types.Locations{
+						{
+							StartLine: 23,
+							EndLine:   26,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -250,6 +292,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 26,
+							EndLine:   29,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -284,6 +332,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-child",
 					Version: "2.0.0",
 					License: "Apache 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 29,
+							EndLine:   32,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -317,6 +371,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 27,
+							EndLine:   30,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -342,6 +402,12 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-api:1.1.1",
 					Name:    "org.example:example-api",
 					Version: "1.1.1",
+					Locations: types.Locations{
+						{
+							StartLine: 19,
+							EndLine:   22,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -369,6 +435,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 26,
+							EndLine:   29,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -401,11 +473,23 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 33,
+							EndLine:   36,
+						},
+					},
 				},
 				{
 					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
+					Locations: types.Locations{
+						{
+							StartLine: 37,
+							EndLine:   41,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -451,11 +535,23 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-dependency2:2.3.4",
 					Name:    "org.example:example-dependency2",
 					Version: "2.3.4",
+					Locations: types.Locations{
+						{
+							StartLine: 18,
+							EndLine:   22,
+						},
+					},
 				},
 				{
 					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
+					Locations: types.Locations{
+						{
+							StartLine: 14,
+							EndLine:   17,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -508,11 +604,23 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
+					Locations: types.Locations{
+						{
+							StartLine: 33,
+							EndLine:   37,
+						},
+					},
 				},
 				{
 					ID:      "org.example:example-nested:3.3.4",
 					Name:    "org.example:example-nested",
 					Version: "3.3.4",
+					Locations: types.Locations{
+						{
+							StartLine: 29,
+							EndLine:   32,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -566,6 +674,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 34,
+							EndLine:   37,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -593,6 +707,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 42,
+							EndLine:   45,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -624,6 +744,12 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-nested:3.3.3",
 					Name:    "org.example:example-nested",
 					Version: "3.3.3",
+					Locations: types.Locations{
+						{
+							StartLine: 25,
+							EndLine:   28,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -655,16 +781,34 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-dependency2:2.3.4",
 					Name:    "org.example:example-dependency2",
 					Version: "2.3.4",
+					Locations: types.Locations{
+						{
+							StartLine: 25,
+							EndLine:   35,
+						},
+					},
 				},
 				{
 					ID:      "org.example:example-dependency:1.2.3",
 					Name:    "org.example:example-dependency",
 					Version: "1.2.3",
+					Locations: types.Locations{
+						{
+							StartLine: 21,
+							EndLine:   24,
+						},
+					},
 				},
 				{
 					ID:      "org.example:example-nested:3.3.3",
 					Name:    "org.example:example-nested",
 					Version: "3.3.3",
+					Locations: types.Locations{
+						{
+							StartLine: 36,
+							EndLine:   46,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -817,6 +961,12 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-nested:3.3.3",
 					Name:    "org.example:example-nested",
 					Version: "3.3.3",
+					Locations: types.Locations{
+						{
+							StartLine: 21,
+							EndLine:   24,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -842,7 +992,7 @@ func TestPom_Parse(t *testing.T) {
 		},
 		{
 			name:      "transitive dependencyManagement should not be inherited",
-			inputFile: "testdata/transitive-dependency-management/pom.xml",
+			inputFile: filepath.Join("testdata", "transitive-dependency-management", "pom.xml"),
 			local:     true,
 			want: []types.Library{
 				// Managed dependencies (org.example:example-api:1.7.30) in org.example:example-dependency-management3
@@ -858,6 +1008,12 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-dependency-management3:1.1.1",
 					Name:    "org.example:example-dependency-management3",
 					Version: "1.1.1",
+					Locations: types.Locations{
+						{
+							StartLine: 15,
+							EndLine:   18,
+						},
+					},
 				},
 				{
 					ID:       "org.example:example-dependency:1.2.3",
@@ -908,6 +1064,12 @@ func TestPom_Parse(t *testing.T) {
 					Name:    "org.example:example-api",
 					Version: "1.7.30",
 					License: "The Apache Software License, Version 2.0",
+					Locations: types.Locations{
+						{
+							StartLine: 28,
+							EndLine:   31,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{
@@ -934,6 +1096,12 @@ func TestPom_Parse(t *testing.T) {
 					ID:      "org.example:example-not-found:999",
 					Name:    "org.example:example-not-found",
 					Version: "999",
+					Locations: types.Locations{
+						{
+							StartLine: 22,
+							EndLine:   25,
+						},
+					},
 				},
 			},
 			wantDeps: []types.Dependency{

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -3,7 +3,6 @@ package pom
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/aquasecurity/go-dep-parser/pkg/types"
 	"io"
 	"maps"
 	"reflect"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
 	"github.com/aquasecurity/go-dep-parser/pkg/utils"
 )
 

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -260,28 +260,34 @@ func (d pomDependency) Resolve(props map[string]string, depManagement, rootDepMa
 
 // ToArtifact converts dependency to artifact.
 // It should be called after calling Resolve() so that variables can be evaluated.
-func (d pomDependency) ToArtifact(ex map[string]struct{}) artifact {
+func (d pomDependency) ToArtifact(opts analysisOptions) artifact {
 	// To avoid shadow adding exclusions to top pom's,
 	// we need to initialize a new map for each new artifact
 	// See `exclusions in child` test for more information
 	exclusions := map[string]struct{}{}
-	if ex != nil {
-		exclusions = maps.Clone(ex)
+	if opts.exclusions != nil {
+		exclusions = maps.Clone(opts.exclusions)
 	}
 	for _, e := range d.Exclusions.Exclusion {
 		exclusions[fmt.Sprintf("%s:%s", e.GroupID, e.ArtifactID)] = struct{}{}
 	}
+
+	var locations types.Locations
+	if opts.lineNumber {
+		locations = types.Locations{
+			{
+				StartLine: d.StartLine,
+				EndLine:   d.EndLine,
+			},
+		}
+	}
+
 	return artifact{
 		GroupID:    d.GroupID,
 		ArtifactID: d.ArtifactID,
 		Version:    newVersion(d.Version),
 		Exclusions: exclusions,
-		Locations: types.Locations{
-			{
-				StartLine: d.StartLine,
-				EndLine:   d.EndLine,
-			},
-		},
+		Locations:  locations,
 	}
 }
 

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -332,7 +332,7 @@ func (deps *pomDependencies) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) er
 
 				dep.EndLine, _ = d.InputPos()
 
-				(*deps).Dependency = append((*deps).Dependency, dep)
+				deps.Dependency = append(deps.Dependency, dep)
 			}
 		}
 	}

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -3,6 +3,7 @@ package pom
 import (
 	"encoding/xml"
 	"fmt"
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
 	"io"
 	"maps"
 	"reflect"
@@ -274,8 +275,12 @@ func (d pomDependency) ToArtifact(ex map[string]struct{}) artifact {
 		ArtifactID: d.ArtifactID,
 		Version:    newVersion(d.Version),
 		Exclusions: exclusions,
-		StartLine:  d.StartLine,
-		EndLine:    d.EndLine,
+		Location: types.Locations{
+			{
+				StartLine: d.StartLine,
+				EndLine:   d.EndLine,
+			},
+		},
 	}
 }
 

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -184,6 +184,7 @@ type pomDependency struct {
 	Scope      string        `xml:"scope"`
 	Optional   bool          `xml:"optional"`
 	Exclusions pomExclusions `xml:"exclusions"`
+	endLine    int
 }
 
 type pomExclusions struct {

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -338,17 +338,17 @@ func lineNumberShift(dep pomDependency) int {
 
 	if dep.Exclusions.Exclusion != nil {
 		shift += 2 // <exclusions> + </exclusions> tags
+		for _, exclusion := range dep.Exclusions.Exclusion {
+			shift += 2 // <exclusion> + </exclusions> tags
+			if exclusion.GroupID != "" {
+				shift += 1
+			}
+			if exclusion.ArtifactID != "" {
+				shift += 1
+			}
+		}
 	}
 
-	for _, exc := range dep.Exclusions.Exclusion {
-		shift += 2 // <exclusion> + </exclusions> tags
-		if exc.GroupID != "" {
-			shift += 1
-		}
-		if exc.ArtifactID != "" {
-			shift += 1
-		}
-	}
 	return shift
 }
 

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -276,7 +276,7 @@ func (d pomDependency) ToArtifact(ex map[string]struct{}) artifact {
 		ArtifactID: d.ArtifactID,
 		Version:    newVersion(d.Version),
 		Exclusions: exclusions,
-		Location: types.Locations{
+		Locations: types.Locations{
 			{
 				StartLine: d.StartLine,
 				EndLine:   d.EndLine,

--- a/pkg/java/pom/pom.go
+++ b/pkg/java/pom/pom.go
@@ -309,7 +309,6 @@ func (props *properties) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error 
 }
 
 func (deps *pomDependencies) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
-	*deps = pomDependencies{}
 	for {
 		token, err := d.Token()
 		if err != nil {

--- a/pkg/java/pom/testdata/parent-properties/pom.xml
+++ b/pkg/java/pom/testdata/parent-properties/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.example</groupId>
             <artifactId>example-api</artifactId>
-            <version>${api.version}</version>
+            <version>2.2.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Description
Add support of line numbers for deps from base pom.xml.

This PR doesn't add line numbers for:
- dependencies from parents
- dependencies for modules

## Related issues
- aquasecurity/trivy/issues/5945