### PR TITLE
Add support for fetching from repository mentioned in pom file

### DIFF
--- a/pkg/java/pom/settings.go
+++ b/pkg/java/pom/settings.go
@@ -8,24 +8,43 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
+type Server struct {
+	ID       string `xml:"id"`
+	Username string `xml:"username"`
+	Password string `xml:"password"`
+}
+
 type settings struct {
-	LocalRepository string `xml:"localRepository"`
+	LocalRepository string   `xml:"localRepository"`
+	Servers         []Server `xml:"servers>server"`
 }
 
 func readSettings() settings {
+	s := settings{}
+	settingsFound := false
+
 	userSettingsPath := filepath.Join(os.Getenv("HOME"), ".m2", "settings.xml")
 	userSettings, err := openSettings(userSettingsPath)
-	if err == nil && userSettings.LocalRepository != "" {
-		return userSettings
+	if err == nil {
+		if userSettings.LocalRepository != "" {
+			return userSettings
+		}
+		s = userSettings
+		settingsFound = true
 	}
 
 	globalSettingsPath := filepath.Join(os.Getenv("MAVEN_HOME"), "conf", "settings.xml")
 	globalSettings, err := openSettings(globalSettingsPath)
-	if err == nil && globalSettings.LocalRepository != "" {
-		return globalSettings
+	if err == nil {
+		if globalSettings.LocalRepository != "" {
+			return globalSettings
+		}
+		if !settingsFound {
+			s = globalSettings
+		}
 	}
 
-	return settings{}
+	return s
 }
 
 func openSettings(filePath string) (settings, error) {


### PR DESCRIPTION
Issue: https://github.com/aquasecurity/go-dep-parser/issues/286
## Description
This change allows packages to be fetched from repository other than https://repo.maven.apache.org/maven2/
- Get username and password from settings file for the corresponding server ID mentioned in the pom file
- Added support for authentication if username and password mentioned while fetching the package