### PR TITLE
fix(pnpm): use `Name` and `Version` fields if present

### DIFF
--- a/pkg/nodejs/pnpm/parse.go
+++ b/pkg/nodejs/pnpm/parse.go
@@ -71,14 +71,13 @@ func (p *Parser) parse(lockVer float64, lockFile LockFile) ([]types.Library, []t
 			continue
 		}
 
-		// Packages from tarball have `name` and `version` fields.
-		// cf. https://github.com/pnpm/spec/blob/ad27a225f81d9215becadfa540ef05fa4ad6dd60/lockfile/5.2.md#packagesdependencypathname
+		// There is cases when `depPath` doesn't contain name ad version of dependency
+		// e.g. packages installed from local directory or tarball
+		// cf. https://github.com/pnpm/spec/blob/274ff02de23376ad59773a9f25ecfedd03a41f64/lockfile/6.0.md#packagesdependencypathname
 		name := info.Name
 		version := info.Version
 
-		// Other packages don't have these fields.
-		// Parse `dependencyPath` to determine name and version.
-		if info.Resolution.Tarball == "" {
+		if name == "" {
 			name, version = parsePackage(depPath, lockVer)
 		}
 		pkgID := p.ID(name, version)

--- a/pkg/nodejs/pnpm/parse.go
+++ b/pkg/nodejs/pnpm/parse.go
@@ -71,7 +71,7 @@ func (p *Parser) parse(lockVer float64, lockFile LockFile) ([]types.Library, []t
 			continue
 		}
 
-		// There is cases when `depPath` doesn't contain name ad version of dependency
+		// Dependency name may be present in dependencyPath or Name field. Same for Version.
 		// e.g. packages installed from local directory or tarball
 		// cf. https://github.com/pnpm/spec/blob/274ff02de23376ad59773a9f25ecfedd03a41f64/lockfile/6.0.md#packagesdependencypathname
 		name := info.Name

--- a/pkg/nodejs/pnpm/parse_testcase.go
+++ b/pkg/nodejs/pnpm/parse_testcase.go
@@ -147,22 +147,35 @@ var (
 	// npm pack
 	// mkdir -p /app/foo/bar && cd /app
 	// cp /temp/node_modules/lodash/lodash-4.17.21.tgz /app/foo/bar/lodash.tgz
+	// npm init -y
 	// npm install ./foo/bar/lodash.tgz
+	// mkdir package1 && cd package1
+	// npm init -y
+	// npm install asynckit@0.4.0
+	// cd ..
+	// npm install ./package1
 	// pnpm update
 	// pnpm add https://github.com/debug-js/debug/tarball/4.3.4
 	// pnpm add https://codeload.github.com/zkochan/is-negative/tar.gz/2fa0531ab04e300a24ef4fd7fb3a280eccb7ccc5
 	// pnpm list --prod --depth 10 | grep -E -o "\S+\s+[0-9]+(\.[0-9]+)+$" | awk '{printf("{ID: \""$1"@"$2"\", Name: \""$1"\", Version: \""$2"\", Indirect: false},\n")}' | sort -u
+	// manually update `Indirect` fields
 	pnpmArchives = []types.Library{
+		{ID: "asynckit@0.4.0", Name: "asynckit", Version: "0.4.0", Indirect: true},
 		{ID: "debug@4.3.4", Name: "debug", Version: "4.3.4", Indirect: false},
 		{ID: "is-negative@2.0.1", Name: "is-negative", Version: "2.0.1", Indirect: false},
 		{ID: "lodash@4.17.21", Name: "lodash", Version: "4.17.21", Indirect: false},
 		{ID: "ms@2.1.2", Name: "ms", Version: "2.1.2", Indirect: true},
+		{ID: "package1@1.0.0", Name: "package1", Version: "1.0.0", Indirect: false},
 	}
 
 	pnpmArchivesDeps = []types.Dependency{
 		{
 			ID:        "debug@4.3.4",
 			DependsOn: []string{"ms@2.1.2"},
+		},
+		{
+			ID:        "package1@1.0.0",
+			DependsOn: []string{"asynckit@0.4.0"},
 		},
 	}
 

--- a/pkg/nodejs/pnpm/testdata/pnpm-lock_archives.yaml
+++ b/pkg/nodejs/pnpm/testdata/pnpm-lock_archives.yaml
@@ -10,8 +10,15 @@ dependencies:
   lodash:
     specifier: file:foo/bar/lodash.tgz
     version: file:foo/bar/lodash.tgz
+  package1:
+    specifier: file:package1
+    version: file:package1
 
 packages:
+
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -42,4 +49,12 @@ packages:
     resolution: {integrity: sha512-fPftOkGbplay6FszUHWPJ8wV7liS+n2gB/UVN0Wv4G71KJWx+8trhGYsbekWqz6TTzkKur67bAdSIIccmKIyLA==, tarball: file:foo/bar/lodash.tgz}
     name: lodash
     version: 4.17.21
+    dev: false
+
+  file:package1:
+    resolution: {directory: package1, type: directory}
+    name: package1
+    version: 1.0.0
+    dependencies:
+      asynckit: 0.4.0
     dev: false


### PR DESCRIPTION
## Description
Dependency name may be present in `dependencyPath` or `Name` field - https://github.com/pnpm/spec/blob/274ff02de23376ad59773a9f25ecfedd03a41f64/lockfile/6.0.md#packagesdependencypathname
Same for Versions.
So we can check `Name` and `Version` fields instead of checking`Resolution`.

## Related Issues:
- aquasecurity/trivy/issues/6032